### PR TITLE
Addressing Issue #12 appending incorrectly

### DIFF
--- a/assimilation_code/programs/obs_seq_to_netcdf/obs_seq_to_netcdf.f90
+++ b/assimilation_code/programs/obs_seq_to_netcdf/obs_seq_to_netcdf.f90
@@ -1,8 +1,6 @@
 ! DART software - Copyright UCAR. This open source software is provided
 ! by UCAR, "as is", without charge, subject to all terms of use at
 ! http://www.image.ucar.edu/DAReS/DART/DART_download
-!
-! $Id$
 
 !> converts an observation sequence file to a netCDF file but only retains
 !> basic metadata. Metadata to specific observation types is not converted.
@@ -49,10 +47,9 @@ use netcdf
 implicit none
 
 ! version controlled file description for error handling, do not edit
-character(len=256), parameter :: source   = &
-   "$URL$"
-character(len=32 ), parameter :: revision = "$Revision$"
-character(len=128), parameter :: revdate  = "$Date$"
+character(len=*), parameter :: source   = 'obs_seq_to_netcdf.f90'
+character(len=*), parameter :: revision = ''
+character(len=*), parameter :: revdate  = ''
 
 !---------------------------------------------------------------------
 !---------------------------------------------------------------------
@@ -455,7 +452,6 @@ ObsFileLoop : do ifile=1, size(obs_seq_filenames)
          ncunit = NC_Compatibility_Check(ncName, iepoch)
       else
          ncunit = InitNetCDF(ncName, iepoch)
-         append_to_netcdf = .true.
       endif
 
       ngood = 0
@@ -1225,7 +1221,6 @@ enddo
 NC_Compatibility_Check = ncid
 
 end function NC_Compatibility_Check
-
 
 
 


### PR DESCRIPTION
The namelist option 'append_to_netcdf' was not implemented properly when there were multiple output files. If there was only 1 file, it has always worked correctly. If 'append_to_netcdf = .false.' the output files are always overwritten, no matter how many of them there are. 