### PR TITLE
Can now specify vloc in pressure for GOES obs converter

### DIFF
--- a/observations/obs_converters/GOES/convert_goes_ABI_L1b.f90
+++ b/observations/obs_converters/GOES/convert_goes_ABI_L1b.f90
@@ -58,8 +58,8 @@ logical  :: verbose = .false.
 
 real(r8) :: obs_err   = MISSING_R8     ! the fixed obs error (std dev, in radiance units)
                                        ! TODO: make this more sophisticated
-real(r8) :: vloc_pres_hPa = MISSING_R8 ! the fixed location to "place" this observation
-                                       ! in hPa
+real(r8) :: vloc_pres_hPa = -1.0_r8    ! the fixed location to "place" this observation
+                                       ! in hPa. Negative means disable and use VERTISUNDEF
 
 namelist /convert_goes_ABI_L1b_nml/ l1_files, l1_file_list, &
                                     outputfile, &
@@ -95,7 +95,7 @@ if (obs_err == MISSING_R8) then
   call error_handler(E_ERR, source, 'An obs_err value was not specified in the namelist, but is required.',source,revision,revdate)
 end if
 
-if (vloc_pres_hPa == MISSING_R8) then
+if (vloc_pres_hPa < 0.0_r8) then
   call error_handler(E_MSG, source, 'No vertical pressure level defined, using VERTISUNDEF.',source,revision,revdate)
 end if
 

--- a/observations/obs_converters/GOES/goes_ABI_L1b_mod.f90
+++ b/observations/obs_converters/GOES/goes_ABI_L1b_mod.f90
@@ -20,7 +20,7 @@ use obs_sequence_mod, only : init_obs_sequence, init_obs, insert_obs_in_seq, &
                              obs_type, set_copy_meta_data, set_qc_meta_data
 
 use     location_mod, only : location_type, set_location, VERTISUNDEF, &
-                             get_location
+                             VERTISPRESSURE, get_location
 
 use     obs_kind_mod,  only : get_index_for_type_of_obs
 
@@ -240,7 +240,7 @@ end subroutine goes_load_ABI_map
 
 subroutine make_obs_sequence (seq, map, lon1, lon2, lat1, lat2, &
                               x_thin, y_thin, goes_num, reject_dqf_1, &
-                              obs_err_spec)
+                              obs_err_spec, vloc_pres_hPa)
 
 type(obs_sequence_type),    intent(inout) :: seq
 type(goes_abi_map_type),    intent(in)    :: map
@@ -249,6 +249,7 @@ integer,                    intent(in)    :: x_thin, y_thin
 integer,                    intent(in)    :: goes_num
 logical,                    intent(in)    :: reject_dqf_1
 real(r8),                   intent(in)    :: obs_err_spec
+real(r8),                   intent(in)    :: vloc_pres_hPa
 
 type(obs_type)          :: obs, prev_obs
 
@@ -338,7 +339,11 @@ sensor_id   = 44  ! ABI
 !  loop over all observations within the file
 
 obs_num = 1
-which_vert = VERTISUNDEF
+if (vloc_pres_hPa == MISSING_R8) then
+    which_vert = VERTISUNDEF
+else
+    which_vert = VERTISPRESSURE
+end if
 
 ! assign each observation the correct observation type
 robstype = get_index_for_type_of_obs(obs_type_name)
@@ -435,8 +440,14 @@ xloop: do ix=1,map%nx
       ! TODO: specify this as a function of channel
       obs_err = obs_err_spec
 
-      ! column integrated value, so no vertical location
-      vloc = 0.0_r8
+      if (vloc_pres_hPa == MISSING_R8) then
+          ! so no vertical location
+          vloc = 0.0_r8
+      else
+          ! assign the integrated column a vertical location
+          ! can correspond to the height of the peak of the weighting function
+          vloc = vloc_pres_hPa*100._r8 ! convert from hPa to Pa
+      end if
 
       ! We don't yet have specularity data to add to the observations.
       if (get_rttov_option_logical('do_lambertian')) then

--- a/observations/obs_converters/GOES/goes_ABI_L1b_mod.f90
+++ b/observations/obs_converters/GOES/goes_ABI_L1b_mod.f90
@@ -339,7 +339,7 @@ sensor_id   = 44  ! ABI
 !  loop over all observations within the file
 
 obs_num = 1
-if (vloc_pres_hPa == MISSING_R8) then
+if (vloc_pres_hPa < 0.0_r8) then
     which_vert = VERTISUNDEF
 else
     which_vert = VERTISPRESSURE
@@ -440,8 +440,8 @@ xloop: do ix=1,map%nx
       ! TODO: specify this as a function of channel
       obs_err = obs_err_spec
 
-      if (vloc_pres_hPa == MISSING_R8) then
-          ! so no vertical location
+      if (vloc_pres_hPa < 0.0_r8) then
+          ! disable pressure location, use VERTISUNDEF, so no single vertical location
           vloc = 0.0_r8
       else
           ! assign the integrated column a vertical location

--- a/observations/obs_converters/GOES/work/input.nml
+++ b/observations/obs_converters/GOES/work/input.nml
@@ -18,8 +18,9 @@
    lat1               =  25.0
    lat2               =  50.0
    goes_num           = 16
-   obs_err            = 0.2
-   verbose            = .false.
+   obs_err            = 1.0
+   verbose            = .true.
+   vloc_pres_hPa      = 340.
  /
 
 &obs_sequence_nml


### PR DESCRIPTION
It's sometimes helpful, even though definitely wrong from a theoretical standpoint, to give a vertical location to satellite observations (which are integrated quantities). This has been an issue with observation-space localization for some time, and this is the standard workaround pioneered by Lili Lei and Jeff Whittaker.