### PR TITLE
fix z'0123' without an explicit int() or real() intrinsic

### DIFF
--- a/assimilation_code/modules/utilities/random_seq_mod.f90
+++ b/assimilation_code/modules/utilities/random_seq_mod.f90
@@ -30,10 +30,9 @@ public :: random_seq_type, &
           random_exponential
 
 ! version controlled file description for error handling, do not edit
-character(len=256), parameter :: source   = &
-   "$URL$"
-character(len=32 ), parameter :: revision = "$Revision$"
-character(len=128), parameter :: revdate  = "$Date$"
+character(len=256), parameter :: source   = "random_seq_mod.f90"
+character(len=32 ), parameter :: revision = ""
+character(len=128), parameter :: revdate  = ""
 
 ! Gives ability to generate unique repeatable sequences of random numbers
 ! using random congruential package. Needed to allow different assim algorithms
@@ -53,12 +52,12 @@ integer, parameter :: N = 624   ! period parameters
 integer, parameter :: M = 397
 
 ! hexadecimal constants
-integer(i8), parameter :: UPPER_MASK  = z'0000000080000000'
-integer(i8), parameter :: LOWER_MASK  = z'000000007FFFFFFF'
-integer(i8), parameter :: FULL32_MASK = z'00000000FFFFFFFF'
-integer(i8), parameter :: magic       = z'000000009908B0DF'
-integer(i8), parameter :: C1          = z'000000009D2C5680'
-integer(i8), parameter :: C2          = z'00000000EFC60000'
+integer(i8), parameter :: UPPER_MASK  = int(z'0000000080000000', i8)
+integer(i8), parameter :: LOWER_MASK  = int(z'000000007FFFFFFF', i8)
+integer(i8), parameter :: FULL32_MASK = int(z'00000000FFFFFFFF', i8)
+integer(i8), parameter :: magic       = int(z'000000009908B0DF', i8)
+integer(i8), parameter :: C1          = int(z'000000009D2C5680', i8)
+integer(i8), parameter :: C2          = int(z'00000000EFC60000', i8)
 
 type random_seq_type
    private

--- a/assimilation_code/modules/utilities/time_manager_mod.f90
+++ b/assimilation_code/modules/utilities/time_manager_mod.f90
@@ -3148,6 +3148,12 @@ function generate_seed(timestamp)
 ! expected to be used to seed a random number generator in a way
 ! that you can reproduce the same sequence if seeded again from
 ! the same time value.
+!
+! the return value needs to be an i4 since seeds are only i4. 
+! compute total number of seconds using a double integer (i8) and 
+! return the least significant 32 bits.  a simple assignment could
+! overflow an i4, and the seed needs to be as unique as possible
+! so preserving the least significant digits is the better choice.
 
 type(time_type), intent(in) :: timestamp
 integer                     :: generate_seed

--- a/assimilation_code/modules/utilities/time_manager_mod.f90
+++ b/assimilation_code/modules/utilities/time_manager_mod.f90
@@ -3159,7 +3159,7 @@ if ( .not. module_initialized ) call time_manager_init
 
 call get_time(timestamp, seconds, days)
 
-generate_seed = iand((secs_day * days) + seconds, z'00000000FFFFFFFF')
+generate_seed = iand((secs_day * days) + seconds, int(z'00000000FFFFFFFF',i8))
 
 end function generate_seed
 


### PR DESCRIPTION
the fortran standard says defining a binary, octal or hexadecimal constant
is not allowed without using one of the numeric intrinsics like int(val, kind)
or real(val, kind) to specify the kind explicitly.  gcc10 now flags this as
an error, which is new.  fix the two places where 'z' constants were being used.