### PR TITLE
One-line fix to bypass posterior inflation update if RTPS option

### DIFF
--- a/assimilation_code/modules/assimilation/filter_mod.f90
+++ b/assimilation_code/modules/assimilation/filter_mod.f90
@@ -1031,7 +1031,8 @@ AdvanceTime : do
    ! (it was applied earlier, this is computing the updated values for
    ! the next cycle.)
 
-   if(do_ss_inflate(post_inflate)) then
+  !if(do_ss_inflate(post_inflate)) then ! CSS commented out
+   if(do_ss_inflate(post_inflate) .and. ( .not. do_rtps_inflate(post_inflate)) ) then ! CSS added second condition. Don't update inflation if RTPS
 
       ! If not reading the sd values from a restart file and the namelist initial
       !  sd < 0, then bypass this entire code block altogether for speed.

--- a/assimilation_code/modules/assimilation/filter_mod.f90
+++ b/assimilation_code/modules/assimilation/filter_mod.f90
@@ -1031,7 +1031,6 @@ AdvanceTime : do
    ! (it was applied earlier, this is computing the updated values for
    ! the next cycle.)
 
-  !if(do_ss_inflate(post_inflate)) then ! CSS commented out
    if(do_ss_inflate(post_inflate) .and. ( .not. do_rtps_inflate(post_inflate)) ) then ! CSS added second condition. Don't update inflation if RTPS
 
       ! If not reading the sd values from a restart file and the namelist initial


### PR DESCRIPTION
When doing posterior state-space inflation, to update inflation, filter_assim is called a second time with inflate_only = .true.  This step is unnecessary if using RTPS inflation, as there's nothing to update when using RTPS.