### PR TITLE
Update POP user_datm.streams & scripts for cesm2_1

### DIFF
--- a/models/POP/shell_scripts/cesm2_1/CESM2_1_setup_hybrid
+++ b/models/POP/shell_scripts/cesm2_1/CESM2_1_setup_hybrid
@@ -689,7 +689,7 @@ foreach FNAME (user*streams*)
    @ filename_index = $#name_parse - 1
    set streamname = $name_parse[$filename_index]
    set   instance = `echo $name_parse[$instance_index] | bc`
-   set   string_instance = `printf _%04d ${instance}`
+   set   string_instance = `printf %04d ${instance}`
 
    if (-e $DARTROOT/models/POP/shell_scripts/$cesmtagmajor/user_$streamname*template) then
 

--- a/models/POP/shell_scripts/cesm2_1/CESM2_1_setup_pmo
+++ b/models/POP/shell_scripts/cesm2_1/CESM2_1_setup_pmo
@@ -690,7 +690,7 @@ foreach FNAME (user*streams*)
    if ( $SingleInstanceRefcase ) then
       set instance = ''
    else
-      set instance = `printf _%04d $TRUTHinstance`
+      set instance = `printf %04d $TRUTHinstance`
    endif
 
    if (-e $DARTROOT/models/POP/shell_scripts/$cesmtagmajor/user_$streamname*template) then

--- a/models/POP/shell_scripts/cesm2_1/user_datm.streams.txt.CPLHISTForcing.Solar_template
+++ b/models/POP/shell_scripts/cesm2_1/user_datm.streams.txt.CPLHISTForcing.Solar_template
@@ -5,7 +5,7 @@
 
     They are available on spinning disk (compressed) on
     the NCAR supercomputers at:
-    /glade/collections/rda/data/ds345.0/cpl
+    /glade/collections/rda/data/ds345.0/cpl_unzipped
 </dataSource>
 <domainInfo>
     <variableNames>
@@ -16,10 +16,10 @@
         doma_mask     mask
     </variableNames>
     <filePath>
-        /glade/p/cisl/dares/johnsonb/CAM_DATM/Reanalysis
+        /glade/collections/rda/data/ds345.0/cpl_unzipped/NINST
     </filePath>
     <fileNames>
-        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cplNINST.ha2x3h.2011.nc
+        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cpl_NINST.ha2x3h.2011.nc
     </fileNames>
 </domainInfo>
 <fieldInfo>
@@ -30,18 +30,18 @@
         a2x3h_Faxa_swvdf     swvdf
     </variableNames>
     <filePath>
-        /glade/p/cisl/dares/johnsonb/CAM_DATM/Reanalysis
+        /glade/collections/rda/data/ds345.0/cpl_unzipped/NINST
     </filePath>
     <fileNames>
-        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cplNINST.ha2x3h.2011.nc
-        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cplNINST.ha2x3h.2012.nc
-        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cplNINST.ha2x3h.2013.nc
-        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cplNINST.ha2x3h.2014.nc
-        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cplNINST.ha2x3h.2015.nc
-        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cplNINST.ha2x3h.2016.nc
-        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cplNINST.ha2x3h.2017.nc
-        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cplNINST.ha2x3h.2018.nc
-        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cplNINST.ha2x3h.2019.nc
+        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cpl_NINST.ha2x3h.2011.nc
+        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cpl_NINST.ha2x3h.2012.nc
+        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cpl_NINST.ha2x3h.2013.nc
+        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cpl_NINST.ha2x3h.2014.nc
+        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cpl_NINST.ha2x3h.2015.nc
+        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cpl_NINST.ha2x3h.2016.nc
+        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cpl_NINST.ha2x3h.2017.nc
+        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cpl_NINST.ha2x3h.2018.nc
+        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cpl_NINST.ha2x3h.2019.nc
     </fileNames>
     <offset>
         -5400

--- a/models/POP/shell_scripts/cesm2_1/user_datm.streams.txt.CPLHISTForcing.State1hr_template
+++ b/models/POP/shell_scripts/cesm2_1/user_datm.streams.txt.CPLHISTForcing.State1hr_template
@@ -5,7 +5,7 @@
 
     They are available on spinning disk (compressed) on
     the NCAR supercomputers at:
-    /glade/collections/rda/data/ds345.0/cpl
+    /glade/collections/rda/data/ds345.0/cpl_unzipped
 </dataSource>
 <domainInfo>
     <variableNames>
@@ -16,10 +16,10 @@
         doma_mask     mask
     </variableNames>
     <filePath>
-        /glade/p/cisl/dares/johnsonb/CAM_DATM/Reanalysis
+        /glade/collections/rda/data/ds345.0/cpl_unzipped/NINST
     </filePath>
     <fileNames>
-        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cplNINST.ha2x1h.2011.nc
+        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cpl_NINST.ha2x1h.2011.nc
     </fileNames>
 </domainInfo>
 <fieldInfo>
@@ -28,21 +28,21 @@
         a2x1h_Sa_v           v
     </variableNames>
     <filePath>
-        /glade/p/cisl/dares/johnsonb/CAM_DATM/Reanalysis
+        /glade/collections/rda/data/ds345.0/cpl_unzipped/NINST
     </filePath>
     <tInterpAlgo>
         linear
     </tInterpAlgo>
     <fileNames>
-        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cplNINST.ha2x1h.2011.nc
-        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cplNINST.ha2x1h.2012.nc
-        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cplNINST.ha2x1h.2013.nc
-        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cplNINST.ha2x1h.2014.nc
-        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cplNINST.ha2x1h.2015.nc
-        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cplNINST.ha2x1h.2016.nc
-        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cplNINST.ha2x1h.2017.nc
-        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cplNINST.ha2x1h.2018.nc
-        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cplNINST.ha2x1h.2019.nc
+        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cpl_NINST.ha2x1h.2011.nc
+        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cpl_NINST.ha2x1h.2012.nc
+        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cpl_NINST.ha2x1h.2013.nc
+        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cpl_NINST.ha2x1h.2014.nc
+        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cpl_NINST.ha2x1h.2015.nc
+        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cpl_NINST.ha2x1h.2016.nc
+        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cpl_NINST.ha2x1h.2017.nc
+        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cpl_NINST.ha2x1h.2018.nc
+        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cpl_NINST.ha2x1h.2019.nc
     </fileNames>
     <offset>
         -1800

--- a/models/POP/shell_scripts/cesm2_1/user_datm.streams.txt.CPLHISTForcing.State3hr_template
+++ b/models/POP/shell_scripts/cesm2_1/user_datm.streams.txt.CPLHISTForcing.State3hr_template
@@ -5,7 +5,7 @@
 
     They are available on spinning disk (compressed) on
     the NCAR supercomputers at:
-    /glade/collections/rda/data/ds345.0/cpl
+    /glade/collections/rda/data/ds345.0/cpl_unzipped
 </dataSource>
 <domainInfo>
     <variableNames>
@@ -16,10 +16,10 @@
         doma_mask     mask
     </variableNames>
     <filePath>
-        /glade/p/cisl/dares/johnsonb/CAM_DATM/Reanalysis
+        /glade/collections/rda/data/ds345.0/cpl_unzipped/NINST
     </filePath>
     <fileNames>
-        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cplNINST.ha2x3h.2011.nc
+        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cpl_NINST.ha2x3h.2011.nc
     </fileNames>
 </domainInfo>
 <fieldInfo>
@@ -34,21 +34,21 @@
         a2x3h_Sa_pslv        pslv
     </variableNames>
     <filePath>
-        /glade/p/cisl/dares/johnsonb/CAM_DATM/Reanalysis
+        /glade/collections/rda/data/ds345.0/cpl_unzipped/NINST
     </filePath>
     <tInterpAlgo>
         linear
     </tInterpAlgo>
     <fileNames>
-        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cplNINST.ha2x3h.2011.nc
-        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cplNINST.ha2x3h.2012.nc
-        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cplNINST.ha2x3h.2013.nc
-        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cplNINST.ha2x3h.2014.nc
-        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cplNINST.ha2x3h.2015.nc
-        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cplNINST.ha2x3h.2016.nc
-        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cplNINST.ha2x3h.2017.nc
-        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cplNINST.ha2x3h.2018.nc
-        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cplNINST.ha2x3h.2019.nc
+        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cpl_NINST.ha2x3h.2011.nc
+        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cpl_NINST.ha2x3h.2012.nc
+        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cpl_NINST.ha2x3h.2013.nc
+        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cpl_NINST.ha2x3h.2014.nc
+        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cpl_NINST.ha2x3h.2015.nc
+        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cpl_NINST.ha2x3h.2016.nc
+        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cpl_NINST.ha2x3h.2017.nc
+        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cpl_NINST.ha2x3h.2018.nc
+        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cpl_NINST.ha2x3h.2019.nc
     </fileNames>
     <offset>
         -5400

--- a/models/POP/shell_scripts/cesm2_1/user_datm.streams.txt.CPLHISTForcing.nonSolarFlux_template
+++ b/models/POP/shell_scripts/cesm2_1/user_datm.streams.txt.CPLHISTForcing.nonSolarFlux_template
@@ -5,7 +5,7 @@
 
     They are available on spinning disk (compressed) on
     the NCAR supercomputers at:
-    /glade/collections/rda/data/ds345.0/cpl
+    /glade/collections/rda/data/ds345.0/cpl_unzipped
 </dataSource>
 <domainInfo>
     <variableNames>
@@ -16,10 +16,10 @@
         doma_mask     mask
     </variableNames>
     <filePath>
-        /glade/p/cisl/dares/johnsonb/CAM_DATM/Reanalysis
+         /glade/collections/rda/data/ds345.0/cpl_unzipped/NINST
     </filePath>
     <fileNames>
-        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cplNINST.ha2x3h.2011.nc
+        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cpl_NINST.ha2x3h.2011.nc
     </fileNames>
 </domainInfo>
 <fieldInfo>
@@ -31,18 +31,18 @@
         a2x3h_Faxa_lwdn      lwdn
     </variableNames>
     <filePath>
-        /glade/p/cisl/dares/johnsonb/CAM_DATM/Reanalysis
+        /glade/collections/rda/data/ds345.0/cpl_unzipped/NINST
     </filePath>
     <fileNames>
-        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cplNINST.ha2x3h.2011.nc
-        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cplNINST.ha2x3h.2012.nc
-        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cplNINST.ha2x3h.2013.nc
-        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cplNINST.ha2x3h.2014.nc
-        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cplNINST.ha2x3h.2015.nc
-        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cplNINST.ha2x3h.2016.nc
-        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cplNINST.ha2x3h.2017.nc
-        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cplNINST.ha2x3h.2018.nc
-        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cplNINST.ha2x3h.2019.nc
+        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cpl_NINST.ha2x3h.2011.nc
+        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cpl_NINST.ha2x3h.2012.nc
+        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cpl_NINST.ha2x3h.2013.nc
+        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cpl_NINST.ha2x3h.2014.nc
+        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cpl_NINST.ha2x3h.2015.nc
+        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cpl_NINST.ha2x3h.2016.nc
+        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cpl_NINST.ha2x3h.2017.nc
+        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cpl_NINST.ha2x3h.2018.nc
+        f.e21.FHIST_BGC.f09_025.CAM6assim.011.cpl_NINST.ha2x3h.2019.nc
     </fileNames>
     <offset>
         -5400


### PR DESCRIPTION
Since the coupler history files for the CAM Reanalysis are now
unzipped on RDA, we edit the POP user_datm.streams* templates and the
CESM2_1 setup scripts for running PMO and setting up a hybrid ensemble
to enable them to make use of the unzipped files.
This fixes Github NCAR/DART Issue #87.

The changes were tested by building a hybrid case using CESM2_1_setup_hybrid
and ensuring that the case ran to completion. Results here:
/glade/work/johnsonb/cases/GNYF.f09_g17_e40.001/ GNYF.f09_g17_e40.001.run.o5254429

CESM2_1_setup_pmo was not run because the changes to it are identical to
those made for CESM2_1_setup_hybrid and the latter script is effectively, in this
case, a superset of the former.