### PR TITLE
mpas rttov 

### DIFF
--- a/models/mpas_atm/model_mod.f90
+++ b/models/mpas_atm/model_mod.f90
@@ -1156,7 +1156,6 @@ logical  :: goodkind, surface_obs
 real(r8) :: lpres(ens_size), values(3, ens_size)
 real(r8) :: llv(3)    ! lon/lat/vert
 integer  :: e, verttype
-integer  :: ierror(ens_size)   ! Ha
 
 if ( .not. module_initialized ) call static_init_model
 
@@ -1901,7 +1900,7 @@ if (vertical_localization_on()) then
       call convert_vert_distrib(state_handle, 1, location_arr, base_qty, vert_localization_coord, istat_arr)
       istatus1 = istat_arr(1)
       base_loc = location_arr(1)
-      if(debug > 5 .and. do_output()) then
+      if(debug > 4 .and. do_output()) then
          call write_location(0,base_loc,charstring=string1)
          call error_handler(E_ALLMSG, 'get_close_obs: base_loc',string1,source, revision, revdate)
      endif

--- a/models/mpas_atm/model_mod.f90
+++ b/models/mpas_atm/model_mod.f90
@@ -1105,7 +1105,6 @@ end subroutine find_mpas_dims
 !>       ISTATUS = 99:  general error in case something terrible goes wrong...
 !>       ISTATUS = 81:  Vertical location too high
 !>       ISTATUS = 80:  Vertical location too low
-!>       ISTATUS = 82:  Vertical location is missing
 !>       ISTATUS = 88:  this kind is not in the state vector
 !>       ISTATUS = 89:  tk cannot be computed.
 !>       ISTATUS = 11:  Could not find the closest cell center that contains this lat/lon
@@ -4593,7 +4592,7 @@ enddo
 ! if the entire ensemble has missing vertical values we can return now.
 ! otherwise we need to continue to convert the members with good vertical values.
 if (all(zin == missing_r8)) then
-   istatus(:) = 0 ! vertisundef might come here - nsc  82    ! FIXME: Ha - Why should this be zero? I created 82 if all zin are missing.
+   istatus(:) = 0 
    return
 endif
 
@@ -4937,7 +4936,7 @@ enddo
 ! if all the vertical localization coord values are missing, 
 ! we don't call this routine again, and return.
 if (all(zin == missing_r8)) then ! .or. on_bound) then
-   istatus(:) = 82    ! FIXME: Ha - Why should this be zero? I created 82 if all zin are missing.
+   istatus(:) = 0
    return
 endif
 

--- a/models/mpas_atm/model_mod.f90
+++ b/models/mpas_atm/model_mod.f90
@@ -7451,6 +7451,15 @@ integer :: e
 qv_nonzero = max(qv,0.0_r8)
 theta_to_tk = missing_r8
 
+if (any(istatus /= 0)) then
+   print *, 'theta_to_tk - nonzero istatus coming in'
+   do e = 1, ens_size
+    if (istatus(e) /= 0) then
+        write(string2, *) 'member ', e, ' incoming istatus = ', istatus(e)
+        call error_handler(E_ALLMSG, 'theta_to_tk',string2,source, revision, revdate)
+    endif  !(istatus(e) /= 0) then
+   enddo   ! ens_size
+endif
 where (istatus == 0)
 
    theta_m = (1.0_r8 + 1.61_r8 * qv_nonzero)*theta

--- a/models/mpas_atm/model_mod.f90
+++ b/models/mpas_atm/model_mod.f90
@@ -1242,7 +1242,7 @@ else
          goodkind = .true.
       case (QTY_PRESSURE)   ! surface pressure should be in the state
          goodkind = .true.
-      case (QTY_SKIN_TEMPERATURE, QTY_SURFACE_TYPE, QTY_CLOUD_FRACTION)   ! Ha: added for rttov
+      case (QTY_SKIN_TEMPERATURE, QTY_SURFACE_TYPE, QTY_CLOUD_FRACTION)   
          goodkind = .true.
       case (QTY_SPECIFIC_HUMIDITY, QTY_2M_SPECIFIC_HUMIDITY)
          goodkind = .true.
@@ -1349,7 +1349,6 @@ else if (obs_kind == QTY_GEOPOTENTIAL_HEIGHT) then
      if(istatus(e) == 0) expected_obs(e) = query_location(location_tmp(e), 'VLOC')
    enddo
 
-   print *, 'model_interpolate: GEOPOTENTIAL_HEIGHT ', istatus(1), expected_obs(1), trim(locstring)
    if ( all(istatus /= 0 ) ) goto 100
 
 else if (obs_kind == QTY_VAPOR_MIXING_RATIO      .or. obs_kind == QTY_2M_SPECIFIC_HUMIDITY   .or. &
@@ -1395,7 +1394,7 @@ else if (obs_kind == QTY_SPECIFIC_HUMIDITY) then
       print *, 'model_interpolate: ', trim(get_name_for_quantity(obs_kind)), istatus(1), &
                                       expected_obs(1), trim(locstring)
 
-! Ha: Only for the variables NOT included in the dart state vector.
+! Only for the variables NOT included in the dart state vector.
 ! Anything included in the state_handle should not go into the case right down here.
 ! ex. QTY_SURFACE_PRESSURE will be taken care of in the else statement (one further down)
 ! as a generic interpolation case thru compute_scalar_with_barycentric
@@ -1461,12 +1460,11 @@ do e = 1, ens_size
          write(string1,*) 'interp routine returned a negative status which is an illegal value'
       else if (istatus(e) /= 0 .and. expected_obs(e) /= MISSING_R8) then
          write(string1,*) 'interp routine returned a bad status but not a MISSING_R8 value'
-         expected_obs(e) = MISSING_R8  ! Ha
+         expected_obs(e) = MISSING_R8  
       else
          write(string1,*) 'interp routine returned a good status but set value to MISSING_R8'
       endif
 
-      !call error_handler(E_ERR,'model_interpolate', string1, source,revision,revdate, &
       call error_handler(E_ALLMSG,'model_interpolate', string1, source,revision,revdate, &
                          text2=string2, text3=string3)
    endif
@@ -3332,8 +3330,8 @@ call nc_get_variable(ncid, 'dcEdge',        dcEdge,        routine)
 call nc_get_variable(ncid, 'zgrid',         zGridFace,     routine)
 call nc_get_variable(ncid, 'cellsOnVertex', cellsOnVertex, routine)
 call nc_get_variable(ncid, 'xland',         xland,         routine)
-call nc_get_variable(ncid, 'seaice',        seaice,        routine)  ! Ha: added for rttov
-call nc_get_variable(ncid, 'skintemp',      skintemp,      routine)  ! Ha: added for rttov
+call nc_get_variable(ncid, 'seaice',        seaice,        routine)
+call nc_get_variable(ncid, 'skintemp',      skintemp,      routine)
 
 dxmax = maxval(dcEdge)  ! max grid resolution in meters
 
@@ -6056,7 +6054,6 @@ call find_vert_level(state_handle, ens_size, loc, nc, c, .true., lower, upper, f
 
 if (debug > 9 .and. do_output()) then
    write(string3,*) 'ier = ',ier(1), ' triangle = ',c(1:nc), ' vert_index = ',lower(1:nc, 1)+fract(1:nc, 1), ' nc = ', nc
-!   write(string3,'(A,I5,A,3I10,A,3F7.2)') 'ier = ',ier(1), ' triangle = ',c(1:nc), ' vert_index = ',lower(1:nc, 1)+fract(1:nc, 1)
    call error_handler(E_MSG, 'find_vert_indices', string3, source, revision, revdate)
 endif
 
@@ -6339,7 +6336,7 @@ select case (use_rbf_option)
                          source, revision, revdate)
 end select
 
-! Ha: Check if any of edges are located in the boundary zone.
+! Check if any of edges are located in the boundary zone.
 ! (We will skip the obs if any edges are located there.)
 if (on_boundary_edgelist(edge_list)) then
    nedges = -1
@@ -7465,7 +7462,7 @@ where (istatus == 0)
 
    theta_m = (1.0_r8 + 1.61_r8 * qv_nonzero)*theta
    
-   where (theta_m > 0.0_r8 .and. rho > 0.0_r8)  ! Check if all the input are positive: Ha
+   where (theta_m > 0.0_r8 .and. rho > 0.0_r8)  ! Check if all the input are positive
 
       exner = ( (rgas/p0) * (rho*theta_m) )**rcv
    
@@ -7504,7 +7501,6 @@ integer,  dimension(ens_size), intent(inout):: istatus
 
 ! Local variables
 real(r8), dimension(ens_size) :: qv_nonzero
-!integer,  dimension(ens_size) :: ierr   ! Ha
 integer   :: e
 
 pressure = missing_r8
@@ -7512,12 +7508,12 @@ qv_nonzero = max(qv,0.0_r8)
 
 tk = theta_to_tk(ens_size, theta, rho, qv_nonzero, istatus)
 
-where (istatus == 0)       ! We only take non-missing tk here: Ha
+where (istatus == 0)       ! We only take non-missing tk here
    pressure = rho * rgas * tk * (1.0_r8 + 1.61_r8 * qv_nonzero)
 end where
 
 if ( debug > 1 ) then
-   if( any(istatus /= 0) ) then   ! Ha
+   if( any(istatus /= 0) ) then   
       do e = 1, ens_size
        if (istatus(e) /= 0) then
            write(string2,'("Failed in member,istatus,P[Pa],tk,theta,rho,qv:",2I4,4F12.2,F15.6)') &

--- a/models/mpas_atm/model_mod.f90
+++ b/models/mpas_atm/model_mod.f90
@@ -1188,6 +1188,7 @@ if (debug > 1 .and. do_output()) &
    print *, 'model_interpolate for obs_kind:',&
              trim(get_name_for_quantity(obs_kind)),' at ',trim(locstring),' cellid:',cellid
 
+! FIXME see issue #96 - remove all but surface elevation
 ! pass surface variables for rttov - it should be ok as these are diagnostic (except for surface elevation).
 if((obs_kind == QTY_SURFACE_PRESSURE) .or. (obs_kind == QTY_SURFACE_ELEVATION)    .or. &
    (obs_kind == QTY_2M_TEMPERATURE)   .or. (obs_kind == QTY_2M_SPECIFIC_HUMIDITY) .or. &
@@ -5023,7 +5024,7 @@ select case (ztypeout)
    endif
 
    if (debug > 9 .and. do_output()) then
-      write(string2,'("zout[m]:",F10.2)') zout(1)
+      write(string2,'("zout[m] for member 1:",F10.2)') zout(1)
       call error_handler(E_MSG, 'convert_vert_distrib_state',string2,source, revision, revdate)
    endif
 
@@ -5105,7 +5106,7 @@ select case (ztypeout)
            endif
         else
            if (debug > 9 .and. do_output()) then
-           write(string2,'("zout [Pa],theta,rho,qv:",3F10.2,F12.8)') fullp(1), values(1:3,1)
+           write(string2,'("zout [Pa] for member 1,theta,rho,qv:",3F10.2,F12.8)') fullp(1), values(1:3,1)
            call error_handler(E_MSG, 'convert_vert_distrib_state',string2,source, revision, revdate)
            endif
         endif      ! istatus
@@ -5626,7 +5627,7 @@ call compute_full_pressure(ens_size, pt(:), density(:), qv(:), pressure(:), tk(:
 if( all(ier/= 0) ) then
     if (debug > 1 .and. do_output()) then
         write(string2,'("Failed in compute_full_pressure")')
-        call error_handler(E_MSG, 'get_interp_pressure',string2,source, revision, revdate)
+        call error_handler(E_ALLMSG, 'get_interp_pressure',string2,source, revision, revdate)
     endif
 else
     if((debug > 11) .and. do_output()) then
@@ -5787,7 +5788,7 @@ do k=1, n
       ! go around triangle and interpolate in the vertical
       ! c(3) are the cell ids
 
-      low_offset = (c(i)-1) * nvert !HK low_offset and upp_offset are the same?
+      low_offset = (c(i)-1) * nvert !FIXME low_offset and upp_offset are the same?
       upp_offset = (c(i)-1) * nvert
 
       if( nvert == 1 ) then         ! fields on a surface (1-D, one level, ...)
@@ -7446,8 +7447,9 @@ integer :: e
 qv_nonzero = max(qv,0.0_r8)
 theta_to_tk = missing_r8
 
-if (any(istatus /= 0)) then
-   if ( debug > 0 .and. do_output()) then 
+
+if ( debug > 0 .and. do_output()) then
+   if (any(istatus /= 0)) then
      print *, 'theta_to_tk - nonzero istatus coming in'
      do e = 1, ens_size
       if (istatus(e) /= 0) then

--- a/models/mpas_atm/model_mod.f90
+++ b/models/mpas_atm/model_mod.f90
@@ -1358,7 +1358,7 @@ else if (obs_kind == QTY_VAPOR_MIXING_RATIO      .or. obs_kind == QTY_2M_SPECIFI
          obs_kind == QTY_ICE_MIXING_RATIO        .or. obs_kind == QTY_SNOW_MIXING_RATIO      .or. &
          obs_kind == QTY_GRAUPEL_MIXING_RATIO    .or. obs_kind == QTY_CLOUD_FRACTION       ) then
    tvars(1) = get_progvar_index_from_kind(obs_kind)
-   call compute_scalar_with_barycentric(state_handle, ens_size, location, 1, tvars, values, istatus)
+   call compute_scalar_with_barycentric(state_handle, ens_size, location, 1, tvars(1), values(1,:), istatus)
    expected_obs = values(1, :)
 
    ! Don't accept negative hydrometeors
@@ -1377,7 +1377,7 @@ else if (obs_kind == QTY_VAPOR_MIXING_RATIO      .or. obs_kind == QTY_2M_SPECIFI
 
 else if (obs_kind == QTY_SPECIFIC_HUMIDITY) then
    tvars(1) = get_progvar_index_from_kind(QTY_VAPOR_MIXING_RATIO)
-   call compute_scalar_with_barycentric(state_handle, ens_size, location, 1, tvars, values, istatus)
+   call compute_scalar_with_barycentric(state_handle, ens_size, location, 1, tvars(1), values(1,:), istatus)
    expected_obs = values(1, :)
 
    ! compute vapor pressure, then: sh = vp / (1.0 + vp)
@@ -1426,7 +1426,7 @@ else
    ! direct interpolation: kind is in the state vector and no clamping or other conversions needed
 
    tvars(1) = ivar
-   call compute_scalar_with_barycentric(state_handle, ens_size, location, 1, tvars, values, istatus)
+   call compute_scalar_with_barycentric(state_handle, ens_size, location, 1, tvars(1), values(1,:), istatus)
    expected_obs = values(1, :)
 
    if (debug > 9 .and. do_output()) &
@@ -4396,7 +4396,7 @@ else if(is_vertical(location, "SURFACE")) then
    ivars(1) = get_progvar_index_from_kind(QTY_SURFACE_PRESSURE)
    if ( ivars(1) >= 0 ) then
 
-     call compute_scalar_with_barycentric(state_handle, ens_size, location, 1, ivars, values, istatus)
+     call compute_scalar_with_barycentric(state_handle, ens_size, location, 1, ivars(1), values(1,:), istatus)
      where (istatus == 0) ploc(:) = values(1,:)
 
    else
@@ -5791,7 +5791,7 @@ do k=1, n
       ! go around triangle and interpolate in the vertical
       ! c(3) are the cell ids
 
-      low_offset = (c(i)-1) * nvert
+      low_offset = (c(i)-1) * nvert !HK low_offset and upp_offset are the same?
       upp_offset = (c(i)-1) * nvert
 
       if( nvert == 1 ) then         ! fields on a surface (1-D, one level, ...)

--- a/models/mpas_atm/model_mod.f90
+++ b/models/mpas_atm/model_mod.f90
@@ -7451,7 +7451,7 @@ qv_nonzero = max(qv,0.0_r8)
 theta_to_tk = missing_r8
 
 if (any(istatus /= 0)) then
-   print *, 'theta_to_tk - nonzero istatus coming in'
+   if ( debug > 0 .and. do_output()) print *, 'theta_to_tk - nonzero istatus coming in'
    do e = 1, ens_size
     if (istatus(e) /= 0) then
         write(string2, *) 'member ', e, ' incoming istatus = ', istatus(e)

--- a/models/mpas_atm/model_mod.f90
+++ b/models/mpas_atm/model_mod.f90
@@ -1254,7 +1254,7 @@ else
    end select
 endif
 
-if (debug > 1 .and. do_output()) &
+if (debug > 10 .and. do_output()) &
    print *, 'model_interpolate: ivar, goodkind? ', ivar, goodkind,' ',&
              trim(get_name_for_quantity(obs_kind)),' at ',trim(locstring)
 
@@ -1262,7 +1262,7 @@ if (debug > 1 .and. do_output()) &
 ! that we know how to handle.
 if (.not. goodkind) then
    istatus(:) = 88
-   if (debug > 1 .and. do_output()) print *, 'model_interpolate: kind rejected', obs_kind
+   if (debug > 4 .and. do_output()) print *, 'model_interpolate: kind rejected', obs_kind
    goto 100
 endif
 

--- a/models/mpas_atm/model_mod.f90
+++ b/models/mpas_atm/model_mod.f90
@@ -4705,7 +4705,7 @@ select case (ztypeout)
    enddo
 
    if (debug > 9 .and. do_output()) then
-      write(string2,'("zout_in_height [m]:",F10.2)') zout(1)
+      write(string2,'("zout_in_height [m] for member 1:",F10.2)') zout(1)
       call error_handler(E_MSG, 'convert_vert_distrib',string2,source, revision, revdate)
    endif
 
@@ -4809,7 +4809,7 @@ select case (ztypeout)
 101 continue
 
      if (debug > 9 .and. do_output()) then
-       write(string2,'("zout_in_scaleheight:",F10.2)') zout(1)
+       write(string2,'("zout_in_scaleheight for member 1:",F10.2)') zout(1)
        call error_handler(E_MSG, 'convert_vert_distrib',string2,source, revision, revdate)
      endif
 
@@ -4959,7 +4959,7 @@ select case (ztypeout)
    zout(:) = vert_level
 
    if (debug > 9 .and. do_output()) then
-      write(string2,'("zout_in_level:",F10.2)') zout(1)
+      write(string2,'("zout_in_level for member 1:",F10.2)') zout(1)
       call error_handler(E_MSG, 'convert_vert_distrib_state',string2,source, revision, revdate)
    endif
 
@@ -5002,7 +5002,7 @@ select case (ztypeout)
        endif
    else
        if (debug > 9 .and. do_output()) then
-           write(string2,'("zout[Pa],theta,rho,qv,ier:",3F10.2,F12.8,I5)') zout(1),values(1:3,1),istatus(1)
+           write(string2,'("zout[Pa] for member 1,theta,rho,qv,ier:",3F10.2,F12.8,I5)') zout(1),values(1:3,1),istatus(1)
            call error_handler(E_MSG, 'convert_vert_distrib_state',string2,source, revision, revdate)
        endif
    endif      ! istatus
@@ -5140,7 +5140,7 @@ select case (ztypeout)
 101 continue
 
      if (debug > 9 .and. do_output()) then
-        write(string2,'("zout_in_scaleheight:",F10.2)') zout(1)
+        write(string2,'("zout_in_scaleheight for member 1:",F10.2)') zout(1)
         call error_handler(E_MSG, 'convert_vert_distrib_state',string2,source, revision, revdate)
      endif
 

--- a/models/mpas_atm/model_mod.f90
+++ b/models/mpas_atm/model_mod.f90
@@ -7451,13 +7451,15 @@ qv_nonzero = max(qv,0.0_r8)
 theta_to_tk = missing_r8
 
 if (any(istatus /= 0)) then
-   if ( debug > 0 .and. do_output()) print *, 'theta_to_tk - nonzero istatus coming in'
-   do e = 1, ens_size
-    if (istatus(e) /= 0) then
-        write(string2, *) 'member ', e, ' incoming istatus = ', istatus(e)
-        call error_handler(E_ALLMSG, 'theta_to_tk',string2,source, revision, revdate)
-    endif  !(istatus(e) /= 0) then
-   enddo   ! ens_size
+   if ( debug > 0 .and. do_output()) then 
+     print *, 'theta_to_tk - nonzero istatus coming in'
+     do e = 1, ens_size
+      if (istatus(e) /= 0) then
+          write(string2, *) 'member ', e, ' incoming istatus = ', istatus(e)
+          call error_handler(E_ALLMSG, 'theta_to_tk',string2,source, revision, revdate)
+      endif  !(istatus(e) /= 0) then
+     enddo   ! ens_size
+   endif
 endif
 where (istatus == 0)
 

--- a/models/mpas_atm/model_mod.f90
+++ b/models/mpas_atm/model_mod.f90
@@ -1329,8 +1329,7 @@ else if (obs_kind == QTY_TEMPERATURE) then
    if (all(istatus /= 0)) goto 100
 
    ! convert pot_temp, density, vapor mixing ratio into sensible temperature
-   expected_obs(:) = theta_to_tk(ens_size, values(1, :), values(2, :), values(3, :), istatus, ierror)
-   istatus = ierror    ! update the status with the error from theta_to_tk: Ha
+   expected_obs(:) = theta_to_tk(ens_size, values(1, :), values(2, :), values(3, :), istatus) 
 
    if (debug > 9 .and. do_output()) &
       print *, 'model_interpolate: TEMPERATURE ', istatus(1), expected_obs(1), trim(locstring)
@@ -5754,10 +5753,11 @@ real(r8),            intent(out) :: dval(n, ens_size)
 integer,             intent(out) :: ier(ens_size)
 integer, optional,   intent(in)  :: this_cellid
 
-real(r8), dimension(3, ens_size) :: fract, lowval, uppval, fdata
+real(r8), dimension(3, ens_size) :: fract, fdata
+real(r8), dimension(ens_size) :: lowval, uppval
 real(r8)    :: weights(3)
 integer     :: c(3), nvert, k, i, nc
-integer(i8) :: index1, low_offset, upp_offset
+integer(i8) :: index1, low_offset, upp_offset, low_state_indx, upp_state_indx
 integer     :: lower(3, ens_size), upper(3,ens_size)
 integer     :: e, e2, thislower, thisupper
 logical     :: did_member(ens_size)
@@ -5825,11 +5825,10 @@ do k=1, n
             do e2=e, ens_size
                if (thislower == lower(i, e2) .and. thisupper == upper(i, e2)) then
                   fdata(i, e2) = lowval(e2)*(1.0_r8 - fract(i, e2)) + uppval(e2)*fract(i, e2)
-!write(*,"(3(A,I3),2(A,F12.4))") 'comp: fld ', k, ', crnr ', i, ', mem ', e2, ', frac ', fract(i, e2), ', data ', fdata(i, e2)
                   did_member(e2) = .true.
                endif
             enddo
-         enddo  ! end ens_size
+         enddo members
 
       endif                         ! 2-D fields
 
@@ -7431,7 +7430,7 @@ end subroutine r3_normalize
 
 !------------------------------------------------------------------
 
-function theta_to_tk (ens_size, theta, rho, qv, istatus) !  _in, istatus_out)  NSC
+function theta_to_tk (ens_size, theta, rho, qv, istatus) 
 
 ! Compute sensible temperature [K] from potential temperature [K].
 ! code matches computation done in MPAS model
@@ -7440,8 +7439,6 @@ integer,                       intent(in)  :: ens_size
 real(r8), dimension(ens_size), intent(in)  :: theta    ! potential temperature [K]
 real(r8), dimension(ens_size), intent(in)  :: rho      ! dry density
 real(r8), dimension(ens_size), intent(in)  :: qv       ! water vapor mixing ratio [kg/kg]
-!integer,  dimension(ens_size), intent(in)  :: istatus_in
-!integer,  dimension(ens_size), intent(out) :: istatus_out
 integer,  dimension(ens_size), intent(inout) :: istatus
 real(r8), dimension(ens_size) :: theta_to_tk          ! sensible temperature [K]
 

--- a/observations/forward_operators/obs_def_rttov_mod.f90
+++ b/observations/forward_operators/obs_def_rttov_mod.f90
@@ -3791,6 +3791,7 @@ end do GETLEVELDATA
 
 
 ! set the surface fields
+! CHECKME rttov elavation vs model evavation 
 ! start with elevation so the other locations can have appropriate vert values
 loc_sea = set_location(loc_lon, loc_lat, 0.0_r8, VERTISSURFACE )
 call interpolate(state_handle, ens_size, loc_sea, QTY_SURFACE_ELEVATION, atmos%sfc_elev(:), this_istatus)
@@ -4005,7 +4006,7 @@ if (is_visir) then
       ! News. Tell the user we are increasing storage.
       write(string1, *) 'Warning: key (',key,') exceeds visir_obs_metadata length (',orglength,')'
       write(string2, *) 'Increasing visir_obs_metadata to length ',newlength
-      call error_handler(E_ALLMSG,routine,string1,source,revision,revdate,text2=string2)
+      call error_handler(E_MSG,routine,string1,source,revision,revdate,text2=string2)
 
       allocate(safe_visir_metadata(orglength))
       safe_visir_metadata(:) = visir_obs_metadata(:)
@@ -4032,7 +4033,7 @@ else
       ! News. Tell the user we are increasing storage.
       write(string1, *) 'Warning: key (',key,') exceeds mw_obs_metadata length (',orglength,')'
       write(string2, *) 'Increasing mw_obs_metadata to length ',newlength
-      call error_handler(E_ALLMSG,routine,string1,source,revision,revdate,text2=string2)
+      call error_handler(E_MSG,routine,string1,source,revision,revdate,text2=string2)
 
       allocate(safe_mw_metadata(orglength))
       safe_mw_metadata(:) = mw_obs_metadata(:)

--- a/observations/forward_operators/obs_def_rttov_mod.f90
+++ b/observations/forward_operators/obs_def_rttov_mod.f90
@@ -310,7 +310,7 @@ module obs_def_rttov_mod
 
 use        types_mod, only : r8, MISSING_R8, MISSING_I, obstypelength
 
-use    utilities_mod, only : register_module, error_handler, E_ERR, E_WARN, E_MSG, &
+use    utilities_mod, only : register_module, error_handler, E_ERR, E_WARN, E_MSG, E_ALLMSG, &
                              ascii_file_format, nmlfileunit, do_nml_file, &
                              do_nml_term, check_namelist_read, find_namelist_in_file, &
                              interactive_r, interactive_i, open_file, file_exist
@@ -2035,7 +2035,7 @@ DO imem = 1, ens_size
          if (debug) then
             write(string1,*) 'For ens #',imem,', pressure ',lvlidx(ilvl),' was greater than or equal to pressure ',&
                 lvlidx(ilvl+1),':',atmos % pressure(imem,lvlidx(ilvl)),' > ',atmos%pressure(imem,lvlidx(ilvl+1))
-            call error_handler(E_MSG,routine,string1,source,revision,revdate)
+            call error_handler(E_ALLMSG,routine,string1,source,revision,revdate)
          end if
 
          radiances(:) = MISSING_R8
@@ -3519,7 +3519,7 @@ if ( .not. arrays_prealloced) then
       write(string1,'(A,I0)') 'FAILED to determine number of levels in model:', &
          numlevels
          
-      if (debug) call error_handler(E_MSG,routine,string1,source,revision,revdate)
+      if (debug) call error_handler(E_ALLMSG,routine,string1,source,revision,revdate)
       istatus = 1
       val     = MISSING_R8
       return
@@ -4001,7 +4001,7 @@ if (is_visir) then
       ! News. Tell the user we are increasing storage.
       write(string1, *) 'Warning: key (',key,') exceeds visir_obs_metadata length (',orglength,')'
       write(string2, *) 'Increasing visir_obs_metadata to length ',newlength
-      call error_handler(E_MSG,routine,string1,source,revision,revdate,text2=string2)
+      call error_handler(E_ALLMSG,routine,string1,source,revision,revdate,text2=string2)
 
       allocate(safe_visir_metadata(orglength))
       safe_visir_metadata(:) = visir_obs_metadata(:)
@@ -4028,7 +4028,7 @@ else
       ! News. Tell the user we are increasing storage.
       write(string1, *) 'Warning: key (',key,') exceeds mw_obs_metadata length (',orglength,')'
       write(string2, *) 'Increasing mw_obs_metadata to length ',newlength
-      call error_handler(E_MSG,routine,string1,source,revision,revdate,text2=string2)
+      call error_handler(E_ALLMSG,routine,string1,source,revision,revdate,text2=string2)
 
       allocate(safe_mw_metadata(orglength))
       safe_mw_metadata(:) = mw_obs_metadata(:)
@@ -4101,7 +4101,7 @@ if (return_now) then
    else if (debug) then
       write(string1,*) 'Could not find requested field ' // trim(field_name), ' istatus:',istatus,&
          'location:',locv(1),'/',locv(2),'/',locv(3)
-      call error_handler(E_MSG,routine,string1,source,revision,revdate)
+      call error_handler(E_ALLMSG,routine,string1,source,revision,revdate)
    end if
 end if
 

--- a/observations/forward_operators/obs_def_rttov_mod.f90
+++ b/observations/forward_operators/obs_def_rttov_mod.f90
@@ -3789,15 +3789,22 @@ GETLEVELDATA : do i = 1,numlevels
 
 end do GETLEVELDATA
 
+! Set the surface fields
+! Some models check that the difference between 'surface' locations and 
+! the surface of the model is within some namelist-specified tolerance.
+! To ensure that these interpolations return useful values, get the model
+! definiiton of the surface and add the appropriate height, if any.
 
-! set the surface fields
-! CHECKME rttov elavation vs model evavation 
-! start with elevation so the other locations can have appropriate vert values
+! Simply check if we can get the model surface elevation (loc_sea is not used)
 loc_sea = set_location(loc_lon, loc_lat, 0.0_r8, VERTISSURFACE )
 call interpolate(state_handle, ens_size, loc_sea, QTY_SURFACE_ELEVATION, atmos%sfc_elev(:), this_istatus)
 call check_status('QTY_SURFACE_ELEVATION', ens_size, this_istatus, val, loc_sea, istatus, routine, source, revision, revdate, .true., return_now)
 if (return_now) return
 
+!>@todo FIXME If the model does not check for surface consistency,
+!>            should we continue ...
+
+! These are the locations of interest. 
 loc_undef = set_location(loc_lon, loc_lat,                MISSING_R8, VERTISUNDEF )
 loc_sfc   = set_location(loc_lon, loc_lat,  0.0_r8+atmos%sfc_elev(1), VERTISSURFACE )
 loc_2m    = set_location(loc_lon, loc_lat,  2.0_r8+atmos%sfc_elev(1), VERTISSURFACE )

--- a/observations/forward_operators/obs_def_rttov_mod.f90
+++ b/observations/forward_operators/obs_def_rttov_mod.f90
@@ -2031,10 +2031,10 @@ DO imem = 1, ens_size
 
    ! check that the pressure is monotonically increasing from TOA down
    do ilvl = 1, nlevels-1
-      if (atmos % pressure(imem,lvlidx(ilvl)) => atmos % pressure(imem,lvlidx(ilvl+1))) then
+      if (atmos % pressure(imem,lvlidx(ilvl)) >= atmos % pressure(imem,lvlidx(ilvl+1))) then
          if (debug) then
             write(string1,*) 'For ens #',imem,', pressure ',lvlidx(ilvl),' was greater than or equal to pressure ',&
-                lvlidx(ilvl+1),':',atmos % pressure(imem,lvlidx(ilvl)),' > ',atmos%pressure(imem,lvlidx(ilvl+1))
+                lvlidx(ilvl+1),':',atmos % pressure(imem,lvlidx(ilvl)),' >= ',atmos%pressure(imem,lvlidx(ilvl+1))
             call error_handler(E_ALLMSG,routine,string1,source,revision,revdate)
          end if
 

--- a/observations/forward_operators/obs_def_rttov_mod.f90
+++ b/observations/forward_operators/obs_def_rttov_mod.f90
@@ -2031,9 +2031,9 @@ DO imem = 1, ens_size
 
    ! check that the pressure is monotonically increasing from TOA down
    do ilvl = 1, nlevels-1
-      if (atmos % pressure(imem,lvlidx(ilvl)) > atmos % pressure(imem,lvlidx(ilvl+1))) then
+      if (atmos % pressure(imem,lvlidx(ilvl)) => atmos % pressure(imem,lvlidx(ilvl+1))) then
          if (debug) then
-            write(string1,*) 'For ens #',imem,', pressure ',lvlidx(ilvl),' was greater than pressure ',&
+            write(string1,*) 'For ens #',imem,', pressure ',lvlidx(ilvl),' was greater than or equal to pressure ',&
                 lvlidx(ilvl+1),':',atmos % pressure(imem,lvlidx(ilvl)),' > ',atmos%pressure(imem,lvlidx(ilvl+1))
             call error_handler(E_MSG,routine,string1,source,revision,revdate)
          end if


### PR DESCRIPTION
Aim of this pull request is to commit the work Nancy and Soyoung did on MPAS and RTTOV. 

Fixes https://github.com/NCAR/DART_development/issues/119

The rttov obs_def changes:
* E_ALLMSG used instead of E_MSG
* loc_sea variable used to create `sfc`, `2m`, `10m` locations relative to model surface elevation
* monotonically decreasing pressure from TOA check now has greater than or **equal to**  ( this is the bug fix)

The mpas_atm model_mod changes:
* Debugging info in the comment at the start of the module. 
* New error code for pressure not monotonically decreasing with level
* QTY_CLOUD_FRACTION added.  Force non-negative hydrometeors and for QTY_CLOUD_FRACTION <1
* `compute_scalar_with_barycentric` passing `tavs(1)`, `values(1,:)`. when `n=1`.  There is some discussion of this in https://github.com/NCAR/DART_development/issues/119.   It is a bit of a gotcha, so is on the list of things to tidy up in the mpas_atm module.
* theta_to_tk has debugging info for non-zero istatus going in

There is some discussion on VERTISUNDEFINED in the comments (whether there should be the error code 82).  

Tested these changes on Cheyenne with a 10 member version on Soyoung's mpas case. Note it was a 10 member test since each restart is 3.7GB.  `/glade/p/cisl/dares/hkershaw/mpas_rttov_testing`