### PR TITLE
write FO values with obs_sequence_tool

### DIFF
--- a/assimilation_code/modules/observations/obs_sequence_mod.f90
+++ b/assimilation_code/modules/observations/obs_sequence_mod.f90
@@ -29,7 +29,8 @@ use      obs_def_mod, only : obs_def_type, get_obs_def_time, read_obs_def, &
                              write_obs_def, destroy_obs_def, copy_obs_def, &
                              interactive_obs_def, get_obs_def_location, &
                              get_obs_def_type_of_obs, get_obs_def_key,  &
-                             operator(==), operator(/=), print_obs_def
+                             operator(==), operator(/=), print_obs_def, &
+                             set_obs_def_write_external_FO
 
 use     obs_kind_mod, only : write_type_of_obs_table, &
                              read_type_of_obs_table, &
@@ -75,13 +76,14 @@ public :: obs_sequence_type, init_obs_sequence, interactive_obs_sequence, &
    delete_seq_head, delete_seq_tail, &
    get_next_obs_from_key, get_prev_obs_from_key, delete_obs_by_typelist, &
    select_obs_by_location, delete_obs_by_qc, delete_obs_by_copy, &
-   print_obs_seq_summary, validate_obs_seq_time
+   print_obs_seq_summary, validate_obs_seq_time, &
+   set_obs_seq_precomputed_FOs
 
 ! Public interfaces for obs
 public :: obs_type, init_obs, destroy_obs, get_obs_def, set_obs_def, &
    get_obs_values, set_obs_values, replace_obs_values, get_qc, set_qc, &  
    read_obs, write_obs, replace_qc, interactive_obs, copy_obs, assignment(=), &
-   get_obs_key, copy_partial_obs, print_obs
+   get_obs_key, copy_partial_obs, print_obs, set_obs_precomputed_FOs
 
 ! Public interfaces for obs covariance modeling
 public :: obs_cov_type
@@ -3036,9 +3038,31 @@ if (obs_count /= size_seq) then
 endif
 
 end subroutine validate_obs_seq_time
+!-------------------------------------------------
+subroutine set_obs_seq_precomputed_FOs(seq,write_external_FOs)
+type(obs_sequence_type), intent(inout) :: seq
+logical,                 intent(in) :: write_external_FOs
 
+integer :: i
 
+do i = 1, seq%num_obs
+  call set_obs_precomputed_FOs(seq%obs(i),write_external_FOs)
+end do
 
+end subroutine set_obs_seq_precomputed_FOs
+!-------------------------------------------------
+subroutine set_obs_precomputed_FOs(obs, write_external_FOs)
+
+! Write out an observation to file, inefficient
+
+type(obs_type), intent(inout) :: obs
+logical,        intent(in) :: write_external_FOs
+
+integer :: i
+
+call set_obs_def_write_external_FO(obs%def, write_external_FOs)
+
+end subroutine set_obs_precomputed_FOs
 !-------------------------------------------------
 !subroutine get_cov_group
 !-------------------------------------------------

--- a/assimilation_code/programs/obs_sequence_tool/obs_sequence_tool.f90
+++ b/assimilation_code/programs/obs_sequence_tool/obs_sequence_tool.f90
@@ -37,7 +37,8 @@ use obs_sequence_mod, only : obs_sequence_type, obs_type, write_obs_seq, &
                              get_obs_key, copy_partial_obs, &
                              delete_obs_from_seq, get_next_obs_from_key, &
                              delete_obs_by_qc, delete_obs_by_copy, &
-                             select_obs_by_location, set_obs_values, set_qc
+                             select_obs_by_location, set_obs_values, set_qc, &
+                             set_obs_seq_precomputed_FOs
 
 implicit none
 
@@ -740,6 +741,9 @@ if (.not. print_only) then
 else
    print*, 'Total number of selected obs in all files :', get_num_key_range(seq_out)
 endif
+
+!setting flag to output precomputed FOs based on namelist
+call set_obs_seq_precomputed_FOs(seq_out,write_external_FOs)
 
 call print_obs_seq(seq_out, filename_out)
 if (.not. print_only) then

--- a/observations/forward_operators/DEFAULT_obs_def_mod.F90
+++ b/observations/forward_operators/DEFAULT_obs_def_mod.F90
@@ -839,7 +839,7 @@ if ( obs_def%has_external_FO .and. obs_def%write_external_FO ) then
          source, revision, revdate, text2='observation type '//trim(get_name_for_type_of_obs(obs_def%kind)))
    endif
    if (is_ascii) then
-      write(ifile, 12) obs_def%ens_size, obs_def%external_FO_key
+      write(ifile, 12) obs_def%ens_size, key
       write(ifile, *) (obs_def%external_FO(ii), ii=1,obs_def%ens_size)
    else
       write(ifile)    obs_def%ens_size, EXTERNAL_PRIOR_CODE


### PR DESCRIPTION
The obs_sequence_tool was not writing out FO values when working with obs_seq.out files that contain FO values. I modified the obs_sequence_tool code along with DEFAULT_obs_sequence_mod.F90 to read the namelist option that users select to have FO values outputted.