### PR TITLE
Bug fix to allow reflectivity forward operator limit check.

### DIFF
--- a/observations/forward_operators/obs_def_radar_mod.f90
+++ b/observations/forward_operators/obs_def_radar_mod.f90
@@ -1127,7 +1127,15 @@ call interpolate(state_handle, ens_size, location, QTY_RADAR_REFLECTIVITY, ref, 
 
 ! If able to get value, QTY_RADAR_REFLECTIVITY is the
 ! the state so you can return here.
-if (any(istatus == 0) ) return
+! Make sure to do apply_ref_limit_to_fwd_op check before "return"ing
+if (any(istatus == 0) ) then
+   if (apply_ref_limit_to_fwd_op) then
+      where ((ref < reflectivity_limit_fwd_op) .and. (istatus == 0))
+         ref = lowest_reflectivity_fwd_op
+      end where
+   endif
+   return
+endif
 
 ! If the user explicitly wanted to interpolate in the field, try to complain
 ! if it could not.  Note that the interp could fail for other reasons.


### PR DESCRIPTION
In observations/forward_operators/obs_def_radar_mod.f90, if reflectivity (QTY_RADAR_REFLECTIVITY) is in the state, right now, the subroutine get_expected_radar_ref immediately "return"s.  However, by returning, the subroutine never gets to apply the "apply_ref_limit_to_fwd_op" check, which is problematic.

This simple fix actually allows the "apply_ref_limit_to_fwd_op" check to happen if reflectivity is in the state.