### PR TITLE
Improved the support for RTPS (inf_flavor 4) posterior inflation: 

### DIFF
--- a/assimilation_code/modules/assimilation/adaptive_inflate_mod.f90
+++ b/assimilation_code/modules/assimilation/adaptive_inflate_mod.f90
@@ -257,7 +257,7 @@ inflate_handle%sd_from_restart      = sd_from_restart
 !parameter, say alpha: 
 !RTPS: lambda = alpha * (sd_b - sd_a) / sd_a + 1
 !where; sd_b (sd_a): prior (posteriro) spread
-if(inf_flavor == 4 .or. inf_flavor == 6) inflate_handle%inflate = 1.0_r8
+if(inf_flavor == 4) inflate_handle%inflate = 1.0_r8
 
 ! Prior and posterior are intialized to false
 if (trim(label)=='Prior') inflate_handle%prior = .true.

--- a/assimilation_code/modules/assimilation/filter_mod.dopplerfold.f90
+++ b/assimilation_code/modules/assimilation/filter_mod.dopplerfold.f90
@@ -1593,7 +1593,11 @@ do group = 1, num_groups
       if ( present(SPARE_PRIOR_SPREAD) .and. present(ENS_SD_COPY)) then 
          write(msgstring, *) ' doing RTPS inflation'
          call error_handler(E_MSG,'filter_ensemble_inflate:',msgstring,source)
-         do j = 1, ens_handle%my_num_vars 
+
+         !Reset the RTPS factor to the given input.nml value
+         ens_handle%copies(inflate_copy, 1:ens_handle%my_num_vars) = inf_initial(2)
+
+         do j = 1, ens_handle%my_num_vars
             call inflate_ens(inflate, ens_handle%copies(grp_bot:grp_top, j), &
                ens_handle%copies(ENS_MEAN_COPY, j), ens_handle%copies(inflate_copy, j), 0.0_r8, &
                ens_handle%copies(SPARE_PRIOR_SPREAD, j), ens_handle%copies(ENS_SD_COPY, j)) 

--- a/assimilation_code/modules/assimilation/filter_mod.f90
+++ b/assimilation_code/modules/assimilation/filter_mod.f90
@@ -1592,9 +1592,10 @@ do group = 1, num_groups
          call error_handler(E_MSG,'filter_ensemble_inflate:',msgstring,source)
          do j = 1, ens_handle%my_num_vars 
 
-            !Reset the RTPS factor to the given input.nml value
-            ens_handle%copies(inflate_copy, j) = inf_initial(2)
- 
+         !Reset the RTPS factor to the given input.nml value
+         ens_handle%copies(inflate_copy, 1:ens_handle%my_num_vars) = inf_initial(2)
+
+         do j = 1, ens_handle%my_num_vars
             call inflate_ens(inflate, ens_handle%copies(grp_bot:grp_top, j), &
                ens_handle%copies(ENS_MEAN_COPY, j), ens_handle%copies(inflate_copy, j), 0.0_r8, &
                ens_handle%copies(SPARE_PRIOR_SPREAD, j), ens_handle%copies(ENS_SD_COPY, j)) 

--- a/assimilation_code/modules/assimilation/filter_mod.f90
+++ b/assimilation_code/modules/assimilation/filter_mod.f90
@@ -1590,7 +1590,6 @@ do group = 1, num_groups
       if ( present(SPARE_PRIOR_SPREAD) .and. present(ENS_SD_COPY)) then 
          write(msgstring, *) ' doing RTPS inflation'
          call error_handler(E_MSG,'filter_ensemble_inflate:',msgstring,source)
-         do j = 1, ens_handle%my_num_vars 
 
          !Reset the RTPS factor to the given input.nml value
          ens_handle%copies(inflate_copy, 1:ens_handle%my_num_vars) = inf_initial(2)

--- a/assimilation_code/modules/assimilation/filter_mod.f90
+++ b/assimilation_code/modules/assimilation/filter_mod.f90
@@ -1591,6 +1591,10 @@ do group = 1, num_groups
          write(msgstring, *) ' doing RTPS inflation'
          call error_handler(E_MSG,'filter_ensemble_inflate:',msgstring,source)
          do j = 1, ens_handle%my_num_vars 
+
+            !Reset the RTPS factor to the given input.nml value
+            ens_handle%copies(inflate_copy, j) = inf_initial(2)
+ 
             call inflate_ens(inflate, ens_handle%copies(grp_bot:grp_top, j), &
                ens_handle%copies(ENS_MEAN_COPY, j), ens_handle%copies(inflate_copy, j), 0.0_r8, &
                ens_handle%copies(SPARE_PRIOR_SPREAD, j), ens_handle%copies(ENS_SD_COPY, j)) 


### PR DESCRIPTION

From Moha:

Improved the support for RTPS (inf_flavor 4) posterior inflation: 

Previously, one could only decide on a single parameter (say, alpha) in the input nml (as inf_initial(2)) without being able to see what is the effective posterior inflation the RTPS scheme is actually using. In other words, if you check the resulting inflation in preassim.nc for instance (variable state_postinf_mean) it would be the same as inf_initial(2). That's incorrect. 

To clarify, there is nothing wrong in the RTPS implementation, however, reporting the output has an issue. The following update corrects the issue and updates the output files with the right posterior inflation values. See the figure below for illustration. The left hand side plot is the value of state_postinf_mean in preassim.nc (or analysis.nc) after running filter. The right hand side is the plot after the proposed code change. Note that both runs use inf_flavor(2) = 4 and inf_initial(2) = 0.3

![Screen Shot 2021-01-13 at 10 28 30 AM](https://user-images.githubusercontent.com/35781176/104487241-191b4f00-558a-11eb-885b-3993c12d8861.png)

Keep in mind that RTPS inflation does not use any files (i.e., inflation has no-memory between DA cycles). 