### PR TITLE
Modify logic for outlier_threshold < 0

### DIFF
--- a/assimilation_code/modules/assimilation/quality_control_mod.f90
+++ b/assimilation_code/modules/assimilation/quality_control_mod.f90
@@ -270,7 +270,8 @@ logical  :: failed
 ! only if it is still successful (assim or eval, 0 or 1), then check
 ! for failing outlier test.
 
-if ( (outlier_threshold < 0) .or. (.not. good_dart_qc(dart_qc)) ) return
+! If bad QC flag exit here.
+if ( .not. good_dart_qc(dart_qc)) return
 
 error   = obs_prior_mean - obs_val
 diff_sd = sqrt(obs_prior_var + obs_err_var)
@@ -288,6 +289,7 @@ endif
 if (enable_special_outlier_code) then
    failed = failed_outlier(ratio, this_obs_key, obs_seq)
 else 
+   if ( outlier_threshold < 0 ) return ! don't modify dart_qc if no outlier check
    failed = (ratio > outlier_threshold)
 endif
 
@@ -371,6 +373,8 @@ select case (this_obs_type)
       else
          failed_outlier = .false.
       endif
+      ! outlier_threshold < 0 means don't do outlier check.
+      if ( outlier_threshold < 0 ) failed_outlier = .false.
 
 end select
 


### PR DESCRIPTION
Currently, to disable the outlier check, we set outlier_threshold < 0 in the namelist.
However, doing so effectively eliminates logic related to **enable_special_outlier_code**; if outlier_threshold < 0, quality_control_mod.f90 never gets to the part where it checks if enable_special_outlier_code is enabled.

This is problematic for someone who might want to disable the outlier check for all obs types _except for _some__.  I came across this issue when I was using precomputed forward operators for all observation types except for radar obs, and I wanted to keep DART's outlier check for radar obs but wanted to eliminate the check for everything else.

Suggested fix restores functionality of enable_special_outlier_code when outlier_threshold < 0