### PR TITLE
bug fix for external forward operators when using distributed_state=.false.

### DIFF
--- a/observations/forward_operators/DEFAULT_obs_def_mod.F90
+++ b/observations/forward_operators/DEFAULT_obs_def_mod.F90
@@ -523,6 +523,7 @@ type(time_type)     :: obs_time
 integer             :: obs_key
 real(r8)            :: error_var
 logical             :: use_precomputed_FO
+integer             :: copy
 
 character(len=512) :: string1, string2, string3
 
@@ -555,7 +556,9 @@ if(assimilate_this_ob .or. evaluate_this_ob) then
 
       if (isprior) then
          if ( obs_def%has_external_FO ) then
-            expected_obs(:) = obs_def%external_FO(1:ens_size) 
+            do copy = 1, ens_size
+               expected_obs(copy) = obs_def%external_FO(copy_indices(copy))
+            enddo
             istatus = 0 
          else 
             call error_handler(E_ERR, 'get_expected_obs_from_def', &


### PR DESCRIPTION

Fixes https://github.com/NCAR/DART/issues/173

Each task has every copy of the precomputed FO because the whole ensemble is in `obs_def%external_F0`

Each task calculates the forward operator for the copies it has.
For distributed_state = true this is the whole ensemble
For distributed_state = false this is a subset of the ensemble.

This fix adds a loop in `get_expected_obs_from_def_distrib_state` to grab the correct subset of copies from `obs_def%external_F0.`