### PR TITLE
obs_info should handle identity obs without crashing

### DIFF
--- a/assimilation_code/programs/obs_utils/obs_info.f90
+++ b/assimilation_code/programs/obs_utils/obs_info.f90
@@ -241,7 +241,7 @@ do fnum = 1, num_input_files
                                              "IDENTITY_OBSERVATIONS"//", ", &
                                              identity_obs%count, ", ", trim(mid_string)
       else
-         write(ounit, '(A32,I8)') "IDENTITY_OBSERVATIONS", identity_obs%count
+         write(ounit, '(A32,I8)') "IDENTITY_OBSERVATIONS          ", identity_obs%count
          call print_date(identity_obs%first_time, '.  First obs:', ounit)
          call print_date(identity_obs%last_time,  '.   Last obs:', ounit)
       endif

--- a/assimilation_code/programs/obs_utils/obs_info.f90
+++ b/assimilation_code/programs/obs_utils/obs_info.f90
@@ -4,6 +4,15 @@
 
 !> print out information about observation sequence file(s).
 !> summarizes obs types, times, counts.
+!>
+!> If 'csv_style_output = .true.' and 'output_file="summary.csv"', 
+!> the resulting comma-separated-values file
+!> can be trivially read into matlab with:
+!>
+!> X = readtable('summary.csv')
+!>
+!> The first line of the output file describes the columns.
+!>
 !>@todo FIXME This routine should use print_obs_seq_summary. 
 
 program obs_info
@@ -128,8 +137,12 @@ if (output_file /= '') then
    ounit = open_file(output_file, action='write')
    write(msgstring, *) 'Output counts will be written to text file: '
    write(msgstring1,*)  trim(output_file)
-   call error_handler(E_MSG,'obs_info',msgstring, &
-                      text2=msgstring1)
+   call error_handler(E_MSG,'obs_info',msgstring, text2=msgstring1)
+
+   if (csv_style_output) then
+      ! The first row of the csv file describes the columns.
+      write(ounit,'(''Filename, ObsTypeInteger, ObsType, Count, AverageTime'')')
+   endif
 else
    ounit = 0
 endif
@@ -225,10 +238,9 @@ do fnum = 1, num_input_files
       if (oinfo(i)%count == 0) cycle ALLTYPES
       if (csv_style_output) then
          call compute_times(oinfo(i)%first_time, oinfo(i)%last_time, avg_string=mid_string)
-         write(ounit, '(A,I8,A,A36,I8,2A)') "'"//trim(filename_in(fnum))//"', ", &
-                                             i, ", ", &
-                                             trim(get_name_for_type_of_obs(i))//", ", &
-                                             oinfo(i)%count, ", ", trim(mid_string)
+         write(ounit, '(A,'','',I8,'','',A36,'','',I8,'','',A)') &
+               trim(filename_in(fnum)), i, trim(get_name_for_type_of_obs(i)), &
+               oinfo(i)%count, trim(mid_string)
       else
          write(ounit, '(A32,I8)') get_name_for_type_of_obs(i), oinfo(i)%count
          call print_date(oinfo(i)%first_time, '.  First obs:', ounit)
@@ -238,10 +250,9 @@ do fnum = 1, num_input_files
    if (identity_obs%count > 0) then
       if (csv_style_output) then
          call compute_times(identity_obs%first_time, identity_obs%last_time, avg_string=mid_string)
-         write(ounit, '(A,I8,A,A36,I8,2A)') "'"//trim(filename_in(fnum))//"', ", &
-                                             -1, ", ", &
-                                             "IDENTITY_OBSERVATIONS"//", ", &
-                                             identity_obs%count, ", ", trim(mid_string)
+         write(ounit, '(A,'','',I8,'','',A36,'','',I8,'','',A)') &
+               trim(filename_in(fnum)), -1, 'IDENTITY_OBSERVATIONS', &
+               identity_obs%count, trim(mid_string)
       else
          write(ounit, '(A32,I8)') "IDENTITY_OBSERVATIONS          ", identity_obs%count
          call print_date(identity_obs%first_time, '.  First obs:', ounit)

--- a/assimilation_code/programs/obs_utils/obs_info.f90
+++ b/assimilation_code/programs/obs_utils/obs_info.f90
@@ -85,11 +85,11 @@ character(len=256)   :: filename_in(MAX_IN_FILES) = ''
 character(len=256)   :: filelist_in = ''
 character(len=32)    :: calendar = 'Gregorian'
 logical              :: filenames_from_terminal = .false.
-logical              :: counts_only = .false.
+logical              :: csv_style_output = .false.
 character(len=256)   :: output_file = ''
 
 
-namelist /obs_info_nml/ filename_in, filelist_in, counts_only, &
+namelist /obs_info_nml/ filename_in, filelist_in, csv_style_output, &
                         calendar, filenames_from_terminal, output_file
 
 !----------------------------------------------------------------
@@ -158,7 +158,7 @@ do fnum = 1, num_input_files
       call error_handler(E_ERR,'obs_info',msgstring)
    endif
    
-   if (.not. counts_only) then
+   if (.not. csv_style_output) then
       write(msgstring,  *) '--------------------------------------------------'
       write(msgstring1, *) 'Starting to process input sequence file: '
       write(msgstring2, *)  trim(filename_in(fnum))
@@ -172,7 +172,7 @@ do fnum = 1, num_input_files
    call validate_obs_seq_time(seq_in, filename_in(fnum))
    
    ! blank line
-   if (.not. counts_only) call error_handler(E_MSG,' ',' ')
+   if (.not. csv_style_output) call error_handler(E_MSG,' ',' ')
    
    ! Initialize individual observation variables
    call init_obs(     obs_in,  num_copies_in, num_qc_in)
@@ -213,7 +213,7 @@ do fnum = 1, num_input_files
       call error_handler(E_MSG,'obs_info', msgstring)
    endif
    
-   if (.not. counts_only) then
+   if (.not. csv_style_output) then
       write(ounit, *) 'Totals for all obs types:'
       write(ounit, *) '  Count: ', all_obs%count
       call print_date(all_obs%first_time, '.  First obs:', ounit)
@@ -223,7 +223,7 @@ do fnum = 1, num_input_files
    ! print out the results
    ALLTYPES: do i=1, max_defined_types_of_obs
       if (oinfo(i)%count == 0) cycle ALLTYPES
-      if (counts_only) then
+      if (csv_style_output) then
          call compute_times(oinfo(i)%first_time, oinfo(i)%last_time, avg_string=mid_string)
          write(ounit, '(A,I8,A,A36,I8,2A)') "'"//trim(filename_in(fnum))//"', ", &
                                              i, ", ", &
@@ -236,7 +236,7 @@ do fnum = 1, num_input_files
       endif
    enddo ALLTYPES
    if (identity_obs%count > 0) then
-      if (counts_only) then
+      if (csv_style_output) then
          call compute_times(identity_obs%first_time, identity_obs%last_time, avg_string=mid_string)
          write(ounit, '(A,I8,A,A36,I8,2A)') "'"//trim(filename_in(fnum))//"', ", &
                                              -1, ", ", &
@@ -254,7 +254,7 @@ do fnum = 1, num_input_files
    call destroy_obs(next_obs_in )
    
    ! blank line only if not doing the CSV output
-   if (.not. counts_only) call error_handler(E_MSG,' ',' ')
+   if (.not. csv_style_output) call error_handler(E_MSG,' ',' ')
 
 enddo
 

--- a/assimilation_code/programs/obs_utils/obs_info.f90
+++ b/assimilation_code/programs/obs_utils/obs_info.f90
@@ -710,7 +710,7 @@ if (present(avg_day) .and. present(avg_sec)) then
    avg_day = aday
    avg_sec = asec
 else if (present(avg_sec)) then
-   avg_sec = asec
+   call get_time(avg_time, avg_sec)
 endif
 
 if (present(avg_string)) then

--- a/assimilation_code/programs/obs_utils/obs_info.f90
+++ b/assimilation_code/programs/obs_utils/obs_info.f90
@@ -158,11 +158,13 @@ do fnum = 1, num_input_files
       call error_handler(E_ERR,'obs_info',msgstring)
    endif
    
-   write(msgstring,  *) '--------------------------------------------------'
-   write(msgstring1, *) 'Starting to process input sequence file: '
-   write(msgstring2, *)  trim(filename_in(fnum))
-   call error_handler(E_MSG,'obs_info',msgstring, &
-                      text2=msgstring1, text3=msgstring2)
+   if (.not. counts_only) then
+      write(msgstring,  *) '--------------------------------------------------'
+      write(msgstring1, *) 'Starting to process input sequence file: '
+      write(msgstring2, *)  trim(filename_in(fnum))
+      call error_handler(E_MSG,'obs_info',msgstring, &
+                         text2=msgstring1, text3=msgstring2)
+   endif
    
    call read_obs_seq(filename_in(fnum), 0, 0, 0, seq_in)
    
@@ -170,7 +172,7 @@ do fnum = 1, num_input_files
    call validate_obs_seq_time(seq_in, filename_in(fnum))
    
    ! blank line
-   call error_handler(E_MSG,' ',' ')
+   if (.not. counts_only) call error_handler(E_MSG,' ',' ')
    
    ! Initialize individual observation variables
    call init_obs(     obs_in,  num_copies_in, num_qc_in)
@@ -251,8 +253,8 @@ do fnum = 1, num_input_files
    call destroy_obs(     obs_in )
    call destroy_obs(next_obs_in )
    
-   ! blank line
-   call error_handler(E_MSG,' ',' ')
+   ! blank line only if not doing the CSV output
+   if (.not. counts_only) call error_handler(E_MSG,' ',' ')
 
 enddo
 

--- a/assimilation_code/programs/obs_utils/obs_info.nml
+++ b/assimilation_code/programs/obs_utils/obs_info.nml
@@ -1,10 +1,10 @@
 
 &obs_info_nml
-   filename_in  = 'obs_seq.out'
-   filelist_in  = ''
-   calendar     = 'Gregorian'
+   filename_in             = ''
+   filelist_in             = ''
+   calendar                = 'Gregorian'
    filenames_from_terminal = .false.
-   counts_only  = .false.
-   output_file  = ''
+   csv_style_output        = .false.
+   output_file             = ''
    /
 

--- a/observations/utilities/oned/input.nml
+++ b/observations/utilities/oned/input.nml
@@ -95,7 +95,7 @@
 &obs_info_nml
    filename_in             = 'obs_seq.out'
    filelist_in             = ''
-   counts_only             = .false.
+   csv_style_output        = .false.
    calendar                = 'none'
    filenames_from_terminal = .false.
    output_file             = ''

--- a/observations/utilities/threed_sphere/input.nml
+++ b/observations/utilities/threed_sphere/input.nml
@@ -210,9 +210,9 @@
 &obs_info_nml
    filename_in             = 'obs_seq.out'
    filelist_in             = ''
-   counts_only             = .false.
-   calendar                = 'Gregorian'
    filenames_from_terminal = .false.
+   calendar                = 'Gregorian'
+   csv_style_output        = .false.
    output_file             = ''
 /
 


### PR DESCRIPTION
made a separate array to store the info for identity obs
rather than try to support negative indices in the oinfo array.

also fix time string formatting if running with no calendar.