### PR TITLE
changes for release email

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Report a problem with DART 
+title: 'bug: '
+labels: bug
+assignees: ''
+
+---
+
+:bug: Your bug may already be reported!
+Please search on the [issue tracker](https://github.com/NCAR/DART/issues) before creating a new issue.
+
+### Describe the bug
+
+1. List the steps someone needs to take to reproduce the bug.  
+2. What was the expected outcome?
+3. What actually happened?  
+
+### Error Message  
+Please provide any error messages.
+
+### Which model(s) are you working with?
+
+###Screenshots   
+If applicable, add screenshots to help explain your problem.
+
+### Version of DART      
+Which version of DART are you using? 
+You can find the version using `git describe --tags`  
+
+### Have you modified the DART code?   
+Yes/No  
+If your code changes are available on GitHub, please provide the repository.
+
+### Build information
+Please describe:  
+ 1. The machine you are running on (e.g. windows laptop, NCAR supercomputer Cheyenne).   
+ 2. The compiler you are using (e.g. gnu, intel).  

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: 'Feature request: ...'
+labels: enhancement
+assignees: ''
+
+---
+
+### Use case  
+What are you trying to accomplish?  Sometimes there may already be a way to do what you need.  
+
+### Is your feature request related to a problem?  
+If so, give a clear and concise description of what the problem is.
+For example, " I'm always frustrated when [...]"
+
+### Describe the your prefered solution  
+Please provide enough detail here to help people have a discussion about your proposal
+
+### Describe any alternatives you have considered  
+List any alternative solutions or workarounds you have considered.
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+## Description:
+<!--- Describe your changes -->
+Please provide a summary of the change and include any relevant motivation and context. 
+
+### Fixes issue
+<!--- link to github issue(s) -->
+
+### Types of changes
+<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+
+### Documentation changes needed?
+<!-- Put an `x` in all the boxes that apply: -->
+- [ ] My change requires a change to the documentation.
+  - [ ] I have updated the documentation accordingly.
+
+### Tests
+Please describe any tests you ran to verify your changes.
+
+## Checklist for merging
+
+- [ ] Updated changelog entry
+- [ ] Documentation updated
+- [ ] Version tag 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,3 +25,9 @@ Please describe any tests you ran to verify your changes.
 - [ ] Updated changelog entry
 - [ ] Documentation updated
 - [ ] Version tag 
+
+## Testing Datasets
+
+- [ ] Dataset needed for testing available upon request
+- [ ] Dataset download instructions included
+- [ ] No dataset needed

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,16 @@ individual files.
 
 The changes are now listed with the most recent at the top.
 
+**May 4 2021 :: issue and pull request templates.  Tag: v9.10.2**
+
+*Github changes*
+
+- Templates for pull requests, bug reports and feature requests
+
+*Documenation updates*
+
+- Removed outdated instructions for checking out a tag
+
 **April 29 2021 :: change default GitHub branch. Tag: v9.10.1**
 
 - Replaced the default branch ("Manhattan") with "main".

--- a/README.md
+++ b/README.md
@@ -21,8 +21,6 @@ DART is available through GitHub. To download the latest version of DART:
 
 ```
 git clone https://github.com/NCAR/DART.git
-cd DART
-git checkout -b v9.10.0-branch tags/v9.10.0 
 ```
 
 #### Citing DART

--- a/README.rst
+++ b/README.rst
@@ -78,47 +78,13 @@ Email dart@ucar.edu for advice if you are interested in a model which has not be
 Quick-start
 -----------
 
-1. fork the NCAR/DART repo
-2. clone your (new) fork to your machine - this will set up a remote named
-   ‘origin’. To clone DART and checkout the latest release, use
+DART is available through `GitHub <https://github.com/NCAR/DART>`__. To
+download the latest version of DART, use:
 
 .. code::
 
-   git clone https://github.com/USERNAME/DART.git
+   git clone https://github.com/NCAR/DART.git
 
-where `USERNAME` is your GitHub username. 
-
-3. create a remote to point back to the NCAR/DART repo … convention dictates
-   that this remote should be called ‘upstream’
-4. Download one of the tar files (listed below) of ‘large’ files so you can test
-   your DART installation.
-5. If you want to issue a PR, create a feature branch and push that to your fork
-   and issue the PR.
-
-There are several large files that are needed to run some of the tests and
-examples but are not included in order to keep the repository as small as
-possible. If you are interested in running *bgrid_solo*, *cam-fv*, or testing
-the *NCEP/prep_bufr* observation converter, you will need these files. These
-files are available at:
-
-+-------------------+------+----------------------------------------------------------------------------------------------------------------------------------+
-| Release           | Size | Filename                                                                                                                         |
-+===================+======+==================================================================================================================================+
-| “Manhattan”       | 189M | `Manhattan_large_files.tar.gz <https://www.image.ucar.edu/pub/DART/Release_datasets/Manhattan_large_files.tar.gz>`__             |
-+-------------------+------+----------------------------------------------------------------------------------------------------------------------------------+
-| “wrf-chem.r13172” | 141M | `wrf-chem.r13172_large_files.tar.gz <https://www.image.ucar.edu/pub/DART/Release_datasets/wrf-chem.r13172_large_files.tar.gz>`__ |
-+-------------------+------+----------------------------------------------------------------------------------------------------------------------------------+
-| “Lanai”           | 158M | `Lanai_large_files.tar.gz <https://www.image.ucar.edu/pub/DART/Release_datasets/Lanai_large_files.tar.gz>`__                     |
-+-------------------+------+----------------------------------------------------------------------------------------------------------------------------------+
-| “Kodiak”          | 158M | `Kodiak_large_files.tar.gz <https://www.image.ucar.edu/pub/DART/Release_datasets/Kodiak_large_files.tar.gz>`__                   |
-+-------------------+------+----------------------------------------------------------------------------------------------------------------------------------+
-| “Jamaica”         | 32M  | `Jamaica_large_files.tar.gz <https://www.image.ucar.edu/pub/DART/Release_datasets/Jamaica_large_files.tar.gz>`__                 |
-+-------------------+------+----------------------------------------------------------------------------------------------------------------------------------+
-| “Hawaii”          | 32M  | `Hawaii_large_files.tar.gz <https://www.image.ucar.edu/pub/DART/Release_datasets/Hawaii_large_files.tar.gz>`__                   |
-+-------------------+------+----------------------------------------------------------------------------------------------------------------------------------+
-
-Download the appropriate tar file and untar it into your DART repository. Ignore
-any warnings about ``tar: Ignoring unknown extended header keyword``.
 
 Go into the ``build_templates`` directory and copy over the closest
 ``mkmf.template``._compiler.system\_ file into ``mkmf.template``.
@@ -161,6 +127,64 @@ other MPI-capable executables with MPI.
 If any of these steps fail or you don’t know how to do them, go to the DART
 project web page listed above for very detailed instructions that should get you
 over any bumps in the process.
+
+Quick-start for developers
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To create a fork of DART for your own development you will need
+a `GitHub <https://github.com/>`__ account. 
+
+1. fork the NCAR/DART repo on GitHub
+2. clone your (new) fork to your machine - this will set up a remote named
+   ‘origin’.
+
+.. code::
+
+   git clone https://github.com/USERNAME/DART.git
+
+where `USERNAME` is your GitHub username. 
+
+3. create a remote to point back to the NCAR/DART repo. Convention dictates
+   that this remote should be called ‘upstream’
+
+.. code::
+
+   git remote add upstream https://github.com/NCAR/DART.git
+
+Use ‘upstream’ to keep your fork up to date with NCAR/DART. GitHub has documentation
+on `working with forks <https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks>`__.
+
+4. Download one of the tar files (listed below) of ‘large’ files so you can test
+   your DART installation.
+5. If you want to contribute your work back to the DART community, create a feature
+   branch with your work, then issue a `pull request <https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request-from-a-fork>`__
+   to propose changes to NCAR/DART.
+
+There are several large files that are needed to run some of the tests and
+examples but are not included in order to keep the repository as small as
+possible. If you are interested in running *bgrid_solo*, *cam-fv*, or testing
+the *NCEP/prep_bufr* observation converter, you will need these files. These
+files are available at:
+
++-------------------+------+----------------------------------------------------------------------------------------------------------------------------------+
+| Release           | Size | Filename                                                                                                                         |
++===================+======+==================================================================================================================================+
+| “Manhattan”       | 189M | `Manhattan_large_files.tar.gz <https://www.image.ucar.edu/pub/DART/Release_datasets/Manhattan_large_files.tar.gz>`__             |
++-------------------+------+----------------------------------------------------------------------------------------------------------------------------------+
+| “wrf-chem.r13172” | 141M | `wrf-chem.r13172_large_files.tar.gz <https://www.image.ucar.edu/pub/DART/Release_datasets/wrf-chem.r13172_large_files.tar.gz>`__ |
++-------------------+------+----------------------------------------------------------------------------------------------------------------------------------+
+| “Lanai”           | 158M | `Lanai_large_files.tar.gz <https://www.image.ucar.edu/pub/DART/Release_datasets/Lanai_large_files.tar.gz>`__                     |
++-------------------+------+----------------------------------------------------------------------------------------------------------------------------------+
+| “Kodiak”          | 158M | `Kodiak_large_files.tar.gz <https://www.image.ucar.edu/pub/DART/Release_datasets/Kodiak_large_files.tar.gz>`__                   |
++-------------------+------+----------------------------------------------------------------------------------------------------------------------------------+
+| “Jamaica”         | 32M  | `Jamaica_large_files.tar.gz <https://www.image.ucar.edu/pub/DART/Release_datasets/Jamaica_large_files.tar.gz>`__                 |
++-------------------+------+----------------------------------------------------------------------------------------------------------------------------------+
+| “Hawaii”          | 32M  | `Hawaii_large_files.tar.gz <https://www.image.ucar.edu/pub/DART/Release_datasets/Hawaii_large_files.tar.gz>`__                   |
++-------------------+------+----------------------------------------------------------------------------------------------------------------------------------+
+
+Download the appropriate tar file and untar it into your DART repository. Ignore
+any warnings about ``tar: Ignoring unknown extended header keyword``.
+
 
 Citing DART
 -----------

--- a/README.rst
+++ b/README.rst
@@ -85,8 +85,6 @@ Quick-start
 .. code::
 
    git clone https://github.com/USERNAME/DART.git
-   cd DART
-   git checkout -b v9.10.0-branch tags/v9.10.0 
 
 where `USERNAME` is your GitHub username. 
 

--- a/conf.py
+++ b/conf.py
@@ -21,7 +21,7 @@ copyright = '2021, University Corporation for Atmospheric Research'
 author = 'Data Assimilation Research Section'
 
 # The full version, including alpha/beta/rc tags
-release = '9.10.0'
+release = '9.10.2'
 master_doc = 'README'
 
 # -- General configuration ---------------------------------------------------

--- a/guide/downloading-dart.rst
+++ b/guide/downloading-dart.rst
@@ -17,8 +17,6 @@ To checkout the latest release of DART:
 .. code:: 
 
    git clone https://github.com/NCAR/DART.git
-   cd DART
-   git checkout -b v9.10.0-branch tags/v9.10.0 
 
 If you have forked the DART repository, replace ``NCAR`` with your
 Github username.


### PR DESCRIPTION

Removed the instructions for checking out the 9.10.0 tag.  Main is now the default branch so people will get the latest version of DART by default when they clone the repository. 

Pull request template - with checklist for updating changelog and tag when merging
Issue templates - bug fix and feature requests. 
You can view what the templates look like here: https://github.com/hkershaw-brown/DART/issues/new/choose

Fixes issue https://github.com/NCAR/DART/issues/212

draft of release email (editable) https://docs.google.com/document/d/1XCbM-9SduixHTmA8vuc8lB-MlHbQarv5g96YVQcnotk/edit?usp=sharing






