### PR TITLE
make create_sphere_obs more general

### DIFF
--- a/observations/obs_converters/obs_error/README.rst
+++ b/observations/obs_converters/obs_error/README.rst
@@ -27,17 +27,18 @@ Anyone who wants to contribute another error module is
 more than welcome to add files here.
 
 IMPORTANT:
-Each file should have the same module name; e.g. the file
-names will differ, but the module name itself must be the
-same across all modules in this directory.
+Each file should have the same module name; i.e. the source
+file names will differ but the module name inside the file
+must be the same across all modules in this directory.
 
-All the subroutines must also have the same names, and
-supply appropriate values for each observation type that
-is required.  If a new observation type is added, it should
+All the subroutines must also have the same names and
+calling sequence. They must return appropriate values 
+for each observation type that is required.  
+If errors for a new observation type is added, it should
 be added to all the files in this directory.
 
 This way the user can change between error values by editing
-the filename in the path_names_xxx files and recompiling,
+the filename in the path_names_xxx files and recompiling
 without changing the code.
 
 Thanks to Ryan Torn for the idea and initial contributions.

--- a/observations/obs_converters/utilities/create_sphere_obs.f90
+++ b/observations/obs_converters/utilities/create_sphere_obs.f90
@@ -152,8 +152,10 @@ do ob = 1, number_of_locations
 
    do lvl = 1, nlvls
 
+      ! in dart vertical locations using pressure are specified in units of pascals
       call set_obs_def_location(obs_def, set_location(deglon, deglat, obs_levels(lvl)*100.0_r8, VERTISPRESSURE))
    
+      ! the standard obs error routines take vertical locations in hectopascals/mb
       t_err = rawin_temp_error(obs_levels(lvl))
       call set_obs_def_error_variance(obs_def, t_err*t_err)
       call set_obs_def_type_of_obs(obs_def, RADIOSONDE_TEMPERATURE)

--- a/observations/obs_converters/utilities/create_sphere_obs.f90
+++ b/observations/obs_converters/utilities/create_sphere_obs.f90
@@ -2,63 +2,87 @@
 ! by UCAR, "as is", without charge, subject to all terms of use at
 ! http://www.image.ucar.edu/DAReS/DART/DART_download
 !
-! $Id$
 
-! create synthetic observations evenly spaced on a sphere.
-! this program creates observations without data - they have
-! a location, type, error variance, a time. run the output file
-! through create_fixed_network_seq if you want a time series of
-! all these obs. run the output through perfect_model_obs to add data. 
+! Create synthetic observations evenly spaced on a sphere.
+!
+! This program creates observations without data.  They have
+! a location, type, error variance, and a time. Run the output file
+! through create_fixed_network_seq if you want to create a time series 
+! of these obs. Run the output through perfect_model_obs to add data. 
 ! 
-! alter as you wish to change obs types, density, etc.
+! Alter as you wish to change obs types, number of types at each loc, etc.
+! If you change the obs types either set the obs error explicitly
+! or change the call to the obs_error module to match the correct obs type.
+!
+! There is a related matlab script in the obs_converters/even_sphere directory
+! which uses the same algorithm to distribute N points around a sphere.  It has
+! additional plotting functions which may be useful.
+
 
 program create_sphere_obs
 
-use         types_mod, only : r8, missing_r8, pi, rad2deg
+use         types_mod, only : r8, pi, rad2deg
 use      location_mod, only : VERTISPRESSURE, set_location
 use     utilities_mod, only : initialize_utilities, finalize_utilities, &
                               find_namelist_in_file, check_namelist_read,         &
                               do_nml_file, do_nml_term, logfileunit, nmlfileunit
-use  time_manager_mod, only : time_type, set_calendar_type, set_date, GREGORIAN, &
-                              get_time
-use  obs_sequence_mod, only : obs_sequence_type, obs_type, read_obs_seq, &
-                              static_init_obs_sequence, init_obs, write_obs_seq, &
-                              init_obs_sequence, get_num_obs, set_obs_def, &
-                              set_copy_meta_data, set_qc_meta_data
+use  time_manager_mod, only : time_type, set_calendar_type, set_date, GREGORIAN
+use  obs_sequence_mod, only : obs_sequence_type, obs_type, init_obs, write_obs_seq, &
+                              init_obs_sequence, set_obs_def
 use      obs_kind_mod, only : RADIOSONDE_U_WIND_COMPONENT, RADIOSONDE_V_WIND_COMPONENT, &
                               RADIOSONDE_TEMPERATURE
-use      obs_def_mod, only : obs_def_type, set_obs_def_time, set_obs_def_type_of_obs, &
-                             set_obs_def_error_variance, set_obs_def_location, &
-                             get_obs_def_time, get_obs_def_location,           &
-                             get_obs_def_type_of_obs, get_obs_def_error_variance,         &
-                             set_obs_def_key
+use       obs_def_mod, only : obs_def_type, set_obs_def_time, set_obs_def_type_of_obs, &
+                              set_obs_def_error_variance, set_obs_def_location
 use obs_utilities_mod, only : add_obs_to_seq
+use       obs_err_mod, only : rawin_temp_error, rawin_wind_error
 
 
 
-! Input is in hectopascals, obs are in pascals
-real(r8) :: obs_levels(15) = (/ 1000., 950., 900., 850., 800., 750., 700., 650., &
-                                 600., 550., 500., 400., 300., 200., 150. /)
+integer  :: iunit, io, ntypes
+real(r8) :: x, y, z, lat, lon, inc, off, r, phi, deglon, deglat
+integer  :: num_obs, ob, lvl, nlvls
 
-! Date information 
-integer :: year = 2008
-integer :: month = 10
-integer :: day = 1
-integer :: hour = 0
-
-! Number of roughly evenly distributed points in horizontal
-integer :: number_of_locations, iunit, io
-real(r8) :: x, y, z, lat, lon, inc, off, r, phi, dlon, dlat
-integer :: num_obs, ob, lvl, nlvls
+integer, parameter :: MAX_LEVELS = 40
+integer, parameter :: DEF_LEVELS = 15
 
 type(time_type) :: time_obs, prev_time
 
 type(obs_sequence_type) :: seq
 type(obs_type)          :: obs, prev_obs
 type(obs_def_type)      :: obs_def
-logical :: first_obs
+logical                 :: first_obs
 
-namelist /create_sphere_obs_nml/ number_of_locations
+! These default levels are standard radiosonde reporting pressures.
+real(r8), parameter :: default_levels(DEF_LEVELS) = (/ 1000.0_r8, 950.0_r8, 900.0_r8, 850.0_r8, 800.0_r8,  &
+                                                        750.0_r8, 700.0_r8, 650.0_r8, 600.0_r8, 550.0_r8,  &
+                                                        500.0_r8, 400.0_r8, 300.0_r8, 200.0_r8, 150.0_r8  /)
+
+! namelist variables
+
+! Number of roughly evenly distributed points in horizontal.
+! Final number of obs will be N * L times this, where N is the
+! number of different obs types at each location and L is the
+! number of pressure levels specified.
+
+integer :: number_of_locations
+
+! The level array here is specified in hectopascals (mb).  
+! Observations are created and stored in pascals.  
+! If this item is not altered by the namelist the default levels are used.
+
+real(r8) :: obs_levels(MAX_LEVELS) =  -1.0_r8
+
+! Date of obs
+integer :: year  = 2008
+integer :: month = 10
+integer :: day   = 1
+integer :: hour  = 0
+
+
+namelist /create_sphere_obs_nml/ number_of_locations, &
+                                 obs_levels, &
+                                 year, month, day, hour
+
 
 
 ! start of executable code
@@ -72,13 +96,26 @@ call check_namelist_read(iunit, io, "create_sphere_obs_nml")
 if (do_nml_file()) write(nmlfileunit, nml=create_sphere_obs_nml)
 if (do_nml_term()) write(     *     , nml=create_sphere_obs_nml)
 
-nlvls = size(obs_levels)
+! if the user doesn't set any levels, use the defaults.
+! otherwise, stop at the first -1 value or end of the array.
 
-! Total number of observations at single time is levels*n*3
-num_obs = nlvls * number_of_locations * 3
+if (all(obs_levels <= 0.0_r8)) then
+   obs_levels(1:DEF_LEVELS) = default_levels
+   nlvls = DEF_LEVELS
+else
+   nlvls = findloc(obs_levels, -1.0_r8, 1) - 1
+   if (nlvls <= 0) nlvls = size(obs_levels)
+endif
 
-! create a new (empty) sequence
-! we define only the location, type, time, and error here.
+! update this if you change the code to have more or fewer 
+! obs types created at each location.
+ntypes = 3   
+
+! Total number of observations at single time is: nlevels * nlocs * ntypes
+num_obs = nlvls * number_of_locations * ntypes
+
+! create a new (empty) sequence.
+! this program defines only the location, type, time, and error.
 ! run perfect_model_obs to fill in the obs values if needed
 call init_obs_sequence(seq, 0, 0, num_obs)
 
@@ -110,18 +147,19 @@ do ob = 1, number_of_locations
    lon = atan2(y, x) + pi
    lat = asin(z)
    
-   dlon = rad2deg * lon
-   dlat = rad2deg * lat
+   deglon = rad2deg * lon
+   deglat = rad2deg * lat
 
    do lvl = 1, nlvls
-      call set_obs_def_location(obs_def, set_location(dlon, dlat, obs_levels(lvl), VERTISPRESSURE))
+
+      call set_obs_def_location(obs_def, set_location(deglon, deglat, obs_levels(lvl)*100.0_r8, VERTISPRESSURE))
    
-      call set_obs_def_error_variance(obs_def, 1.0_r8)
+      call set_obs_def_error_variance(obs_def, rawin_temp_error(obs_levels(lvl)))
       call set_obs_def_type_of_obs(obs_def, RADIOSONDE_TEMPERATURE)
       call set_obs_def(obs, obs_def)  
       call add_obs_to_seq(seq, obs, time_obs, prev_obs, prev_time, first_obs)
    
-      call set_obs_def_error_variance(obs_def, 4.0_r8)
+      call set_obs_def_error_variance(obs_def, rawin_wind_error(obs_levels(lvl)))
       call set_obs_def_type_of_obs(obs_def, RADIOSONDE_U_WIND_COMPONENT)
       call set_obs_def(obs, obs_def) 
       call add_obs_to_seq(seq, obs, time_obs, prev_obs, prev_time, first_obs)
@@ -134,15 +172,10 @@ do ob = 1, number_of_locations
 
 enddo
 
-call write_obs_seq(seq, 'even_sphere.in')
+call write_obs_seq(seq, 'even_sphere_seq.in')
 
 call finalize_utilities('create_sphere_obs')
 
 end program create_sphere_obs
 
-! <next few lines under version control, do not edit>
-! $URL$
-! $Id$
-! $Revision$
-! $Date$
 

--- a/observations/obs_converters/utilities/create_sphere_obs.f90
+++ b/observations/obs_converters/utilities/create_sphere_obs.f90
@@ -155,18 +155,18 @@ do ob = 1, number_of_locations
       call set_obs_def_location(obs_def, set_location(deglon, deglat, obs_levels(lvl)*100.0_r8, VERTISPRESSURE))
    
       t_err = rawin_temp_error(obs_levels(lvl))
-      call set_obs_def_error_variance(obs_def, t_err)
+      call set_obs_def_error_variance(obs_def, t_err*t_err)
       call set_obs_def_type_of_obs(obs_def, RADIOSONDE_TEMPERATURE)
       call set_obs_def(obs, obs_def)  
       call add_obs_to_seq(seq, obs, time_obs, prev_obs, prev_time, first_obs)
    
       w_err = rawin_wind_error(obs_levels(lvl))
-      call set_obs_def_error_variance(obs_def, w_err)
+      call set_obs_def_error_variance(obs_def, w_err*w_err)
       call set_obs_def_type_of_obs(obs_def, RADIOSONDE_U_WIND_COMPONENT)
       call set_obs_def(obs, obs_def) 
       call add_obs_to_seq(seq, obs, time_obs, prev_obs, prev_time, first_obs)
    
-      call set_obs_def_error_variance(obs_def, w_err)
+      call set_obs_def_error_variance(obs_def, w_err*w_err)
       call set_obs_def_type_of_obs(obs_def, RADIOSONDE_V_WIND_COMPONENT)
       call set_obs_def(obs, obs_def) 
       call add_obs_to_seq(seq, obs, time_obs, prev_obs, prev_time, first_obs)

--- a/observations/obs_converters/utilities/create_sphere_obs.f90
+++ b/observations/obs_converters/utilities/create_sphere_obs.f90
@@ -39,7 +39,7 @@ use       obs_err_mod, only : rawin_temp_error, rawin_wind_error
 
 
 integer  :: iunit, io, ntypes
-real(r8) :: x, y, z, lat, lon, inc, off, r, phi, deglon, deglat
+real(r8) :: x, y, z, lat, lon, inc, off, r, phi, deglon, deglat, t_err, w_err
 integer  :: num_obs, ob, lvl, nlvls
 
 integer, parameter :: MAX_LEVELS = 40
@@ -154,16 +154,19 @@ do ob = 1, number_of_locations
 
       call set_obs_def_location(obs_def, set_location(deglon, deglat, obs_levels(lvl)*100.0_r8, VERTISPRESSURE))
    
-      call set_obs_def_error_variance(obs_def, rawin_temp_error(obs_levels(lvl)))
+      t_err = rawin_temp_error(obs_levels(lvl))
+      call set_obs_def_error_variance(obs_def, t_err)
       call set_obs_def_type_of_obs(obs_def, RADIOSONDE_TEMPERATURE)
       call set_obs_def(obs, obs_def)  
       call add_obs_to_seq(seq, obs, time_obs, prev_obs, prev_time, first_obs)
    
-      call set_obs_def_error_variance(obs_def, rawin_wind_error(obs_levels(lvl)))
+      w_err = rawin_wind_error(obs_levels(lvl))
+      call set_obs_def_error_variance(obs_def, w_err)
       call set_obs_def_type_of_obs(obs_def, RADIOSONDE_U_WIND_COMPONENT)
       call set_obs_def(obs, obs_def) 
       call add_obs_to_seq(seq, obs, time_obs, prev_obs, prev_time, first_obs)
    
+      call set_obs_def_error_variance(obs_def, w_err)
       call set_obs_def_type_of_obs(obs_def, RADIOSONDE_V_WIND_COMPONENT)
       call set_obs_def(obs, obs_def) 
       call add_obs_to_seq(seq, obs, time_obs, prev_obs, prev_time, first_obs)

--- a/observations/obs_converters/utilities/create_sphere_obs.f90
+++ b/observations/obs_converters/utilities/create_sphere_obs.f90
@@ -52,7 +52,7 @@ type(obs_type)          :: obs, prev_obs
 type(obs_def_type)      :: obs_def
 logical                 :: first_obs
 
-! These default levels are standard radiosonde reporting pressures.
+! These default levels are standard radiosonde reporting pressures in hectopascals.
 real(r8), parameter :: default_levels(DEF_LEVELS) = (/ 1000.0_r8, 950.0_r8, 900.0_r8, 850.0_r8, 800.0_r8,  &
                                                         750.0_r8, 700.0_r8, 650.0_r8, 600.0_r8, 550.0_r8,  &
                                                         500.0_r8, 400.0_r8, 300.0_r8, 200.0_r8, 150.0_r8  /)
@@ -177,5 +177,4 @@ call write_obs_seq(seq, 'even_sphere_seq.in')
 call finalize_utilities('create_sphere_obs')
 
 end program create_sphere_obs
-
 

--- a/observations/obs_converters/utilities/threed_sphere/input.nml
+++ b/observations/obs_converters/utilities/threed_sphere/input.nml
@@ -26,6 +26,11 @@
 
 &create_sphere_obs_nml
    number_of_locations = 25
+   obs_levels          = -1
+   year                = 2012 
+   month               = 5
+   day                 = 1
+   hour                = 0
    /
 
 &utilities_nml

--- a/observations/obs_converters/utilities/threed_sphere/path_names_create_sphere_obs
+++ b/observations/obs_converters/utilities/threed_sphere/path_names_create_sphere_obs
@@ -21,5 +21,4 @@ observations/forward_operators/obs_def_mod.f90
 observations/forward_operators/obs_def_utilities_mod.f90
 observations/obs_converters/utilities/create_sphere_obs.f90
 observations/obs_converters/utilities/obs_utilities_mod.f90
-observations/utilities/obs_utilities_mod.f90
 observations/obs_converters/obs_error/ncep_obs_err_mod.f90

--- a/observations/obs_converters/utilities/threed_sphere/path_names_create_sphere_obs
+++ b/observations/obs_converters/utilities/threed_sphere/path_names_create_sphere_obs
@@ -21,3 +21,5 @@ observations/forward_operators/obs_def_mod.f90
 observations/forward_operators/obs_def_utilities_mod.f90
 observations/obs_converters/utilities/create_sphere_obs.f90
 observations/obs_converters/utilities/obs_utilities_mod.f90
+observations/utilities/obs_utilities_mod.f90
+observations/obs_converters/obs_error/ncep_obs_err_mod.f90


### PR DESCRIPTION
## Description:

updates to create_sphere_obs to make it more general:

- additional items have been added to the namelist so they can
be changed at runtime rather than at compile time.
- the errors for radiosonde obs are now taken from the ncep (or ecmwf)
error module.
- a bug in the pressure values has been fixed. the original version kept
them in hectopascals instead of converting to pascals.
- additional comments have been added about the matlab version..
- minor wordsmithing in the obs_error README for clarity.
- NOT DONE, but should be:
 after kevin's pull request is accepted i would like to move this
 file into the even_sphere directory.  it isn't a utility and having
 it along with the build files in the same directory as the matlab
 means it will be easier to find.  the readme will need updating so
 i want to wait until that's on the main branch before making other
 changes.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [x] My change requires a change to the documentation.
  - [x] I have NOT updated the documentation accordingly.
(i'm waiting for kevin's pull request to be resolved so i can update the same README in the even_sphere dir.)

### Tests
I constructed several different namelist values for create_sphere_obs and examined the output.

## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Version tag 

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [ ] No dataset needed
