### PR TITLE
bugfix for issue #246 quad_vals

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,11 @@ individual files.
 
 The changes are now listed with the most recent at the top.
 
+**June 24 2021 :: bug fix for cam-fv model_interpolate. Tag: v.9.11.3**
+
+- cam-fv model_interpolate now passes the correct array slice of quad_vals
+  to quad_lon_lat_evaluate
+
 **June 24 2021 :: latest version of local particle filter.  Tag: v9.11.2**
 
 - latest version of particle filter from Jon Potterjoy

--- a/conf.py
+++ b/conf.py
@@ -21,7 +21,7 @@ copyright = '2021, University Corporation for Atmospheric Research'
 author = 'Data Assimilation Research Section'
 
 # The full version, including alpha/beta/rc tags
-release = '9.11.2'
+release = '9.11.3'
 master_doc = 'README'
 
 # -- General configuration ---------------------------------------------------

--- a/models/cam-fv/model_mod.f90
+++ b/models/cam-fv/model_mod.f90
@@ -844,7 +844,7 @@ do imem=1,ens_size
    ! do the horizontal interpolation for each ensemble member.
    ! call one at a time to avoid creating temporary arrays
    call quad_lon_lat_evaluate(interp_handle, lon_fract, lat_fract, &
-                              quad_vals(:,imem), interp_vals(imem), status_array(imem))
+                              quad_vals(imem,:), interp_vals(imem), status_array(imem))
 end do
 
 if (using_chemistry) &


### PR DESCRIPTION
## Description:
Fix cam-fv model_mod to pass correct quad_vals to quad_lon_lat_evaluate. 

fixes issue #246

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

### Tests

Tested with cam-fv on Cheyenne 8 member ensemble
/glade/scratch/hkershaw/DART/Bugs/bug_246/cam_fv/[test_fix test_main]

*Note*:

quad_utils_mod.f90 uses ` invals(4, nitems)`
cam-fv/model_mod.f90 uses  `quad_vals(ens_size,4) !< array of interpolated values`

which seems ripe for bugs such as #246.   I'm not sure why the change in order was made, maybe should be reverted. 

## Checklist for merging

- [x] Updated changelog entry
- [ ] Documentation updated
- [x] Version tag 

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [ ] No dataset needed
