### PR TITLE
bug-fix: initialize uniquek to an invalid level.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,11 @@ individual files.
 
 The changes are now listed with the most recent at the top.
 
+**July 23 2021 :: bug fix for wrf non-initialized unique levels. Tag: v9.11.4**
+
+- The array uniquek is now initialized to an invalid level to prevent random
+  reasonable level values in the array.
+
 **June 24 2021 :: bug fix for cam-fv model_interpolate. Tag: v.9.11.3**
 
 - cam-fv model_interpolate now passes the correct array slice of quad_vals

--- a/conf.py
+++ b/conf.py
@@ -21,7 +21,7 @@ copyright = '2021, University Corporation for Atmospheric Research'
 author = 'Data Assimilation Research Section'
 
 # The full version, including alpha/beta/rc tags
-release = '9.11.3'
+release = '9.11.4'
 master_doc = 'README'
 
 # -- General configuration ---------------------------------------------------

--- a/models/wrf/model_mod.f90
+++ b/models/wrf/model_mod.f90
@@ -1297,7 +1297,7 @@ else
    enddo
 
    allocate(uniquek(count))
- 
+   uniquek(:) = -1 
    uk = 1
    do e = 1, ens_size
       if ( all(uniquek /= k(e)) ) then
@@ -1871,6 +1871,7 @@ else
       enddo
    
       allocate(uniquek(count))
+      uniquek(:) = -1 
     
       uk = 1
       do e = 1, ens_size
@@ -2701,6 +2702,7 @@ else
          enddo
       
          allocate(uniquek(count))
+         uniquek(:) = -1 
        
          uk = 1
          do e = 1, ens_size


### PR DESCRIPTION
Fixes issue #258

## Description:
<!--- Describe your changes -->
Initialize uniqiek in wrf model_mod to have an invalid level

### Fixes issue
<!--- link to github issue(s) -->
Fixes #258 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

### Tests
Please describe any tests you ran to verify your changes.
Bitwise with main branch (caveat the 288 processor case which showed the bug). 
Cheyenne, intel & gnu compilers.

## Checklist for merging

- [x] Updated changelog entry
- [ ] Documentation updated
- [x] Version tag 

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [x] Dataset download instructions included
- [ ] No dataset needed

Test case here: 
/glade/work/hkershaw/DART/cheyenne_run288