### PR TITLE
New test for verifying one-sided MPI communication 

### DIFF
--- a/developer_tests/mpi_utilities/tests/Makefile
+++ b/developer_tests/mpi_utilities/tests/Makefile
@@ -2,16 +2,16 @@
 # by UCAR, "as is", without charge, subject to all terms of use at
 # http://www.image.ucar.edu/DAReS/DART/DART_download
 #
-# DART $Id$
 
 # Makefile for various mpi test and timing programs
 #
-# This Makefile directly 'include's the mkmf.template file used by the 
+# This Makefile directly includes the mkmf.template file used by the 
 #  mkmf system.  If the mkmf.template is set wrong for this system, 
-#  these builds will fail.  See ../../mkmf/mkmf.template.* for various
-#  compiler and platform settings.
+#  these builds will fail.  See ../../../build_templates directory
+#  for various different compiler and platform files..
 
 include ../../../build_templates/mkmf.template
+
 
 # the include defines the following makefile variables:
 # MPIFC =    # mpi fortran wrapper
@@ -24,25 +24,37 @@ include ../../../build_templates/mkmf.template
 # LIBS =     # any additional libraries needed
 # LDFLAGS += $(FFLAGS) -L$(NETCDF)/lib -lnetcdf  # loader flags
 
+# if you want to test the C programs, you will need to
+# define CC and MPICC here because they are not defined in
+# the standard DART templates
+CC    = gcc    # c compiler (e.g. gcc, icc, cc)
+MPICC = mpicc  # mpi wrapper for cc
+
+# one test uses the DART utilities
+UTILS_DIR = ../../../assimilation_code/modules/utilities
+
 # ----------------------------------------------------------------------------
 
 SRC = ftest_f90.f90 ftest_mpi.f90 ftest_sendrecv.f90 ftest_nc.f90 \
-      ftest_stop.f90 ftest_go.f90 ctest.c ctest_mpi.c ctest_nc.c
+      ftest_onesided.f90 ftest_stop.f90 ftest_go.f90 \
+      ctest.c ctest_mpi.c ctest_nc.c
 
 ALLSRC = $(SRC) Makefile README runme_*
 
-EXE = ftest_f90 ftest_mpi ftest_nc ftest_sendrecv
+EXE = ftest_f90 ftest_mpi ftest_nc ftest_sendrecv ftest_onesided
 ALLEXE = $(EXE) ftest_stop ftest_go ctest ctest_mpi ctest_nc
 
 # ----------------------------------------------------------------------------
 
 # default target - build and test only what is necessary for dart
-all:  $(EXE)
-
+all:  fixsys $(EXE)
 
 # all executables - if you are having problems, this might help diagnose
 # what parts of the install are giving problems
-everything: $(ALLEXE)
+everything: fixsys $(ALLEXE)
+
+fixsys:
+	./fixsystem $(FC)
 
 
 # run the basic executables interactively
@@ -50,6 +62,7 @@ check:  all
 	./ftest_f90                   # this should run
 	./ftest_nc                    # this should run
 	mpirun -np 2 ./ftest_mpi      # this may not be allowed on a login node
+	mpirun -np 2 ./ftest_onesided # this may not be allowed on a login node
 
 # submit the jobs to a batch queue
 batch: ftest_mpi
@@ -74,11 +87,14 @@ ftest_f90: ftest_f90.f90
 ftest_mpi: ftest_mpi.f90
 	$(MPIFC) ftest_mpi.f90 $(LDFLAGS) -o ftest_mpi
 
-# f90 test program that calls MPI functions
+# f90 test program that uses DART MPI utility routines
 ftest_sendrecv: ftest_sendrecv.f90 types_mod.o utilities_mod.o time_manager_mod.o mpi_utilities_mod.o
 	$(MPIFC) ftest_sendrecv.f90 types_mod.o utilities_mod.o time_manager_mod.o mpi_utilities_mod.o $(LDFLAGS) -o ftest_sendrecv
 
-UTILS_DIR = ../../../assimilation_code/modules/utilities
+# test of MPI one-sided communication
+ftest_onesided: ftest_onesided.f90 
+	$(MPIFC) ftest_onesided.f90 $(LDFLAGS) -o ftest_onesided
+
 
 types_mod.o: $(UTILS_DIR)/types_mod.f90
 	$(MPIFC) $(FFLAGS) -c $<
@@ -90,6 +106,7 @@ time_manager_mod.o: $(UTILS_DIR)/time_manager_mod.f90
 	$(MPIFC) $(FFLAGS) -c $<
 
 mpi_utilities_mod.o: $(UTILS_DIR)/mpi_utilities_mod.f90
+	cd $(UTILS_DIR); ./fixsystem $(FC)
 	$(MPIFC) $(FFLAGS) -c $<
 
 # f90 test program that calls netCDF functions
@@ -108,19 +125,19 @@ ftest_go: ftest_go.f90
 
 # DART uses no C code, but if you want to test whether your system has 
 # working C interfaces for MPI or netCDF, you can use these programs.
-# Edit 'gcc' below, if needed, to reference your own C compiler.
+# define CC and MPICC below, if needed, to reference your own C compiler
 
 # simple c program without mpi or netcdf
 ctest: ctest.c
-	gcc ctest.c -o ctest
+	$(CC) ctest.c -o ctest
 
 # c test program that calls MPI functions
 ctest_mpi: ctest_mpi.c
-	mpicc ctest_mpi.c -o ctest_mpi
+	$(MPICC) ctest_mpi.c -o ctest_mpi
 
 # c test program that calls netCDF functions
 ctest_nc: ctest_nc.c
-	gcc -I$(NETCDF)/include ctest_nc.c -L$(NETCDF)/lib -lnetcdf -o ctest_nc
+	$(CC) -I$(NETCDF)/include ctest_nc.c -L$(NETCDF)/lib -lnetcdf -o ctest_nc
 
 
 
@@ -158,7 +175,7 @@ sanity:
 # ----------------------------------------------------------------------------
 
 clean:
-	rm -f *.o *.mod $(ALLEXE) out_* *testdata.nc
+	rm -f *.o *.mod $(ALLEXE) out_* *testdata.nc *.orig
 
 tar:
 	tar -zcvf ~/comm.tar.gz $(ALLSRC)
@@ -166,7 +183,3 @@ tar:
 untar:
 	tar -zxvf ~/comm.tar.gz
 
-# <next few lines under version control, do not edit>
-# $URL$
-# $Revision$
-# $Date$

--- a/developer_tests/mpi_utilities/tests/README
+++ b/developer_tests/mpi_utilities/tests/README
@@ -1,8 +1,6 @@
 # DART software - Copyright UCAR. This open source software is provided
 # by UCAR, "as is", without charge, subject to all terms of use at
 # http://www.image.ucar.edu/DAReS/DART/DART_download
-#
-# DART $Id$
 
 Greetings.  This README file contains information about the programs
 in this directory, and troubleshooting help if you are trying to get
@@ -11,11 +9,9 @@ the MPI option in DART to compile and run.
 
 INTRODUCTION:
 
-Starting with the Jamaica release of DART there is an option to use MPI
-in the filter program, to do the data assimilation step in parallel on a
-parallel machine.  There is also the option to have the model advance in
-parallel as well.  This is controlled by the 'async' namelist setting in
-the &filter_nml namelist section of the input.nml file.
+For most models with a large state vector DART needs to use MPI in
+the filter program to do the data assimilation step in parallel on a
+multiprocessor machine. 
 
 The default settings compile DART without MPI, but if you want to enable
 that option you need to have a working MPI library and run-time system.
@@ -26,14 +22,14 @@ are multiple Fortran compilers or if MPI is not installed in a standard
 directory.
 
 This directory contains some small test programs which use both MPI and
-the netCDF libraries.  It may be simpler to debug any build problems here,
-and if you need to submit a problem report to your system admin people
+the netCDF libraries.  It may be simpler to debug any build problems here.
+If you need to submit a problem report to your system admin people
 these single executables are much simpler than the entire DART build tree.
 
-Be sure that the file $DART/mkmf/mkmf.template has been updated for your
-particular system and compiler.  We supply a default file but generally
-you find the mkmf.template.compiler.system file which is closest to your
-setup, copy it over mkmf.template, and then update the location of the
+Be sure that the file $DART/build_templates/mkmf.template has been updated 
+for your particular system and compiler. Usually you find the 
+mkmf.template.compiler.system file which is closest to your setup, 
+copy it to mkmf.template, and then update the location of the
 netCDF libraries (since they are often not installed in a location searched
 by default).  If your system uses the 'module' commands to select
 different versions, make sure you have consistent versions of the Fortran
@@ -60,19 +56,19 @@ almost infinite number of permutations of batch queue systems, compilers,
 and mpi libraries.
 
 Examples of batch queue systems:  PBS, LSF, LoadLeveler
-Examples of compiler vendors: Intel (ifort), PGI (pgf90), Absoft (f95)
+Examples of compiler vendors: Intel (ifort), PGI (pgf90), GNU (gfortran)
 Examples of MPI libraries:  mpich, LAM, OpenMPI, MPT
 
 
 Make sure that the closest mkmf.template.compiler.system file has 
-been copied over to $DART/mkmf/mkmf.template.
+been copied to $DART/mkmf/mkmf.template.
 
 Type:  make
 to compile the programs.
 
 Type:  make check
 to run the programs interactively and look for errors.  Note that on
-some larger systems it is prohibited to run MPI programs on the login
+some larger systems it can be prohibited to run MPI programs on the login
 nodes; they can only be submitted to a batch system.  If the f90 and nc
 programs run but the mpi program fails, you still might be ok.  Move
 on to 'make batch' before declaring an emergency.
@@ -192,6 +188,14 @@ this program to debug netcdf problems.  Try: make ftest_nc (to compile), then:
 ./ftest_nc to run.  It should create a small netcdf file called ftestdata.nc
 which can be dumped with "ncdump ftestdata.nc".
 
+ftest_onesided.f90 is an MPI program that uses the MPI routine MPI_Get()
+to copy data from remote tasks.  DART uses this feature and on some systems
+it is possible that basic MPI functions work but one-sided functions have
+problems.  If this test fails, submit it to your system support group.
+
+The following two programs are not often used anymore, but are here
+for historical reason.
+
 ftest_stop.f90 and ftest_go.f90 are MPI test programs for the async=4
 MPI model advance option.  If you are using async = 4 for filter and
 are having problems, try running this pair.  In particular pay attention
@@ -202,9 +206,9 @@ to run this test.  You may have to edit the Makefile to select the
 proper batch system.
 
 
-ctest.c is a C language program.  The Fortran executables have no dependency
-on C, but if there is any question about whether there is a working C
-compiler on the system, try:  make ctest.
+ctest.c is a C language program.  DART is written completely in Fortran
+so this is not needed to build DART.  But if there is any question about 
+whether there is a working C compiler on the system, try:  make ctest.
 
 ctest_mpi.c is a C language program which uses the C versions of the MPI
 library calls.  DART does not have any C code in it, but it is possible
@@ -222,13 +226,9 @@ not, that might be a useful clue.  Try: make ctest_nc (to compile), then:
 ./ctest_nc to run.  It should create a small netcdf file called ctestdata.nc
 which can be dumped with "ncdump ctestdata.nc".
 
-Any questions, email me at:  nancy@ucar.edu
+Any questions, email the DART team at:  dart@ucar.edu
 
 
-Good luck -
+Good Luck -
 nancy collins
 
-# <next few lines under version control, do not edit>
-# $URL$
-# $Revision$
-# $Date$

--- a/developer_tests/mpi_utilities/tests/fixsystem
+++ b/developer_tests/mpi_utilities/tests/fixsystem
@@ -1,0 +1,151 @@
+#!/bin/sh 
+#
+# DART software - Copyright UCAR. This open source software is provided
+# by UCAR, "as is", without charge, subject to all terms of use at
+# http://www.image.ucar.edu/DAReS/DART/DART_download
+#
+# usage: fixsystem [ your_fortran_command_name | -help  ] 
+#         (e.g. ifort, pgf90, gfortran, g95, xlf90, etc)
+#
+# this script updates the mpi source files for any compiler-dependent
+# changes needed before building.
+# 
+# at the moment the only compiler-dependent code is the declaration
+# of the "system()" function in a fortran interface block.
+# the code uses this function to run a shell script or command and 
+# wait for the command exit code, e.g.:  rc = system("/bin/date")
+#
+# for all compilers, except gfortran, an interface block is required
+# to define the integer return from the system function.  however
+# the gfortran compiler gives an error if this block is defined.
+# this script enables and disables this interface block by
+# looking for a pair of specially formatted comment lines and
+# commenting in (or out) all the lines between those comment 
+# delimiter lines.
+#
+# the original usage of this script was without any arguments. 
+# the backwards compatibility remains for now, but is deprecated.
+# usage now is to give it a single argument - the name that the
+# fortran compiler is invoked with, e.g. ifort, xlf90, pgf90, etc.
+# it will ensure that any required changes to the source will be
+# made here before compilation.
+
+
+for f in *.f90
+do
+
+  # figure out what state the source file is in before we start
+  export bline1="`fgrep SYSTEM_BLOCK_EDIT ${f} | grep START | head -n 1`"
+  if [ "`echo $bline1 | grep COMMENTED_OUT`" != ""  ]; then
+    export before1=out
+  elif [ "`echo $bline1 | grep COMMENTED_IN`" != ""  ]; then
+    export before1=in
+  else
+    echo ${f} does not need updating
+    export before1=none
+  fi
+  
+  # NAG sections have both in and out - but NAG_BLOCK_EDIT is key
+  export bline2="`fgrep NAG_BLOCK_EDIT ${f} | grep START | head -n 1`"
+  if [ "`echo $bline2 | grep COMMENTED_OUT`" != ""  ]; then
+    export before2=out
+  elif [ "`echo $bline2 | grep COMMENTED_IN`" != ""  ]; then
+    export before2=in
+  else
+    export before2=none
+  fi
+
+  # no args given - error.  required now.
+  if [ $# = 0 ]; then
+      echo invalid usage, 1 argument required by $0
+      echo "usage: $0 [ your_fortran_command_name | -help  ]"
+      echo "  e.g. $0 gfortran"
+      echo "  or   $0 ifort "
+      echo "  or   $0 pgf90 "
+      echo "  etc."
+      exit 1
+  elif [ $# = 1 ]; then
+    # single arg: the name of your fortran compiler command
+    if ([ "$1" = help ] || [ "$1" = -help ] || [ "$1" = --help ]); then
+      echo "usage: $0 [ your_fortran_command_name | -help  ]"
+      echo "  e.g. $0 gfortran"
+      echo "  or   $0 ifort "
+      echo "  or   $0 pgf90 "
+      echo "  etc."
+      exit 1
+    elif ([ "$1" = gfortran ] || [ "$1" = nagfor ]); then
+      export todo1=out
+      export todo2=out
+    elif [ "$1" = nagfor ]; then
+      export todo1=out
+      export todo2=in
+    else
+      export todo1=in
+      export todo2=out
+    fi
+    export compiler=$1
+
+  else
+    # too many arguments, give an error message and exit
+    echo invalid usage, more than 1 argument given to $0
+    echo "usage: $0 [ your_fortran_command_name | -help  ]"
+    echo "  e.g. $0 gfortran"
+    echo "  or   $0 ifort "
+    echo "  or   $0 pgf90 "
+    echo "  etc."
+    exit 1
+  fi
+  
+  # if we have nothing to do, loop to next file
+  if ([ $before1 = none ] && [ $before2 = none ]); then continue; fi
+
+  # if we are already in the right state, loop to next file
+  if ([ $before1 = $todo1 ] && [ $before2 = $todo2 ]); then continue; fi
+ 
+  # save original copy for backup if one does not already exist.
+  if [ ! -f ${f}.orig ]; then
+    cp -p ${f} ${f}.orig
+  fi
+  
+  # say what compiler we are doing this for, and move the existing
+  # code into a temporary file so the sed command does not overwrite it.
+  echo Setting for $compiler compiler in ${f}
+  mv ${f} tempfile
+
+  # removing comment chars, enabling interface block code
+  if [ $todo1 = in ]; then
+   sed -e '/SYSTEM_BLOCK_EDIT START COMMENTED_OUT/,/SYSTEM_BLOCK_EDIT END COMMENTED_OUT/s/^!//' \
+       -e '/\(SYSTEM_BLOCK_EDIT [A-Z][A-Z]*\) COMMENTED_OUT/s//\1 COMMENTED_IN/' tempfile > ${f}
+   mv ${f} tempfile
+  fi
+  
+  # adding comment chars, disabling interface block code
+  if [ $todo1 = out ]; then
+   sed -e '/SYSTEM_BLOCK_EDIT START COMMENTED_IN/,/SYSTEM_BLOCK_EDIT END COMMENTED_IN/s/^/!/' \
+       -e '/\(SYSTEM_BLOCK_EDIT [A-Z][A-Z]*\) COMMENTED_IN/s//\1 COMMENTED_OUT/' tempfile > ${f}
+   mv ${f} tempfile
+  fi
+
+  # changing comment chars, enabling NAG specific block code
+  # non-nag section headers cannot match nag headers.
+  if [ $todo2 = in ]; then
+   sed -e '/NAG_BLOCK_EDIT START COMMENTED_OUT/,/NAG_BLOCK_EDIT END COMMENTED_OUT/s/^!//' \
+       -e '/\(NAG_BLOCK_EDIT [A-Z][A-Z]*\) COMMENTED_OUT/s//\1 COMMENTED_IN/' \
+       -e '/OTHER_BLOCK_EDIT START COMMENTED_IN/,/OTHER_BLOCK_EDIT END COMMENTED_IN/s/^/!/' \
+       -e '/\(OTHER_BLOCK_EDIT [A-Z][A-Z]*\) COMMENTED_IN/s//\1 COMMENTED_OUT/' tempfile > ${f}
+  fi
+  
+  # changing comment chars, disabling NAG specific block code
+  if [ $todo2 = out ]; then
+   sed -e '/NAG_BLOCK_EDIT START COMMENTED_IN/,/NAG_BLOCK_EDIT END COMMENTED_IN/s/^/!/' \
+       -e '/\(NAG_BLOCK_EDIT [A-Z][A-Z]*\) COMMENTED_IN/s//\1 COMMENTED_OUT/' \
+       -e '/OTHER_BLOCK_EDIT START COMMENTED_OUT/,/OTHER_BLOCK_EDIT END COMMENTED_OUT/s/^!//' \
+       -e '/\(OTHER_BLOCK_EDIT [A-Z][A-Z]*\) COMMENTED_OUT/s//\1 COMMENTED_IN/' tempfile > ${f}
+  fi
+
+  \rm -f tempfile
+
+done
+
+exit 0
+

--- a/developer_tests/mpi_utilities/tests/ftest_go.f90
+++ b/developer_tests/mpi_utilities/tests/ftest_go.f90
@@ -2,7 +2,6 @@
 ! by UCAR, "as is", without charge, subject to all terms of use at
 ! http://www.image.ucar.edu/DAReS/DART/DART_download
 !
-! $Id$
 
 program ftest_go
 
@@ -44,16 +43,18 @@ implicit none
 ! you an error about an undefined symbol (something like '_system_').  
 ! Comment this block in or out as needed.
 
-!  ! interface block for getting return code back from system() routine
-!  interface
-!   function system(string)
-!    character(len=*) :: string
-!    integer :: system
-!   end function system
-!  end interface
-!  ! end block
+! interface block for getting return code back from system() routine
 
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+ !!SYSTEM_BLOCK_EDIT START COMMENTED_IN
+   interface
+    function system(string)
+     character(len=*) :: string
+     integer :: system
+    end function system
+   end interface
+ !!SYSTEM_BLOCK_EDIT END COMMENTED_IN
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 
 ! integer variables
@@ -154,7 +155,6 @@ end subroutine block_task
 !-----------------------------------------------------------------------------
 subroutine restart_task()
 
-
 character(len = 32) :: fifo_name
 integer :: rc
 logical :: verbose
@@ -175,14 +175,8 @@ logical :: verbose
    rc = system('echo restart > '//trim(fifo_name)//' '//char(0))
    
    if (verbose) write(*,*) 'response was read from lock file: '//trim(fifo_name)
-   
 
 end subroutine restart_task
 
 end program ftest_go
 
-! <next few lines under version control, do not edit>
-! $URL$
-! $Id$
-! $Revision$
-! $Date$

--- a/developer_tests/mpi_utilities/tests/ftest_mpi.f90
+++ b/developer_tests/mpi_utilities/tests/ftest_mpi.f90
@@ -1,8 +1,6 @@
 ! DART software - Copyright UCAR. This open source software is provided
 ! by UCAR, "as is", without charge, subject to all terms of use at
 ! http://www.image.ucar.edu/DAReS/DART/DART_download
-!
-! $Id$
 
 program ftest_mpi
 
@@ -43,14 +41,15 @@ implicit none
 ! you an error about an undefined symbol (something like '_system_').  
 ! Comment this block in or out as needed.
 
-! ! interface block for getting return code back from system() routine
-! interface
-!  function system(string)
-!   character(len=*) :: string
-!   integer :: system
-!  end function system
-! end interface
-! ! end block
+! interface block for getting return code back from system() routine
+ !!SYSTEM_BLOCK_EDIT START COMMENTED_IN
+   interface
+    function system(string)
+     character(len=*) :: string
+     integer :: system
+    end function system
+   end interface
+ !!SYSTEM_BLOCK_EDIT END COMMENTED_IN
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
@@ -104,8 +103,3 @@ integer :: ierror, myrank, totalprocs, rc
 
 end program ftest_mpi
 
-! <next few lines under version control, do not edit>
-! $URL$
-! $Id$
-! $Revision$
-! $Date$

--- a/developer_tests/mpi_utilities/tests/ftest_onesided.f90
+++ b/developer_tests/mpi_utilities/tests/ftest_onesided.f90
@@ -1,0 +1,351 @@
+! DART software - Copyright UCAR. This open source software is provided
+! by UCAR, "as is", without charge, subject to all terms of use at
+! http://www.image.ucar.edu/DAReS/DART/DART_download
+
+program ftest_onesided
+
+! MPI Fortran program that tests one-sided MPI communication.
+! this is used in DART for tasks to retrieve data from other
+! tasks without having to interrupt them or make them synchronize
+! with the requesting task.
+
+use mpi
+
+implicit none
+
+! if your MPI installation does not include an mpi module,
+! comment out the 'use mpi' line above and comment in this
+! include file.  if you have a choice, the module is better.
+!include "mpif.h"
+
+! data kinds
+integer, parameter :: r8 = SELECTED_REAL_KIND(12) 
+integer, parameter :: datasize = MPI_REAL8
+
+! source, destination arrays, byte sizes, item counts, etc
+integer :: our_window 
+integer :: window_items = 1000
+integer(MPI_OFFSET_KIND) :: window_size
+integer(MPI_OFFSET_KIND) :: window_offset
+
+real(r8), allocatable :: contiguous_array(:)
+real(r8), allocatable :: target_array(:) 
+integer :: target_count = 10
+
+integer :: owner_task  
+integer :: ierror
+integer :: myrank
+integer :: total_tasks
+
+! set this to true to get more output.
+! beware - it will print lines from each MPI task
+! so it could be very verbose for large task counts.
+logical :: verbose = .false.
+
+
+! start of executable code
+call setup_mpi()
+
+
+
+! each task makes a window and fills it with
+! unique numbers. 
+
+call create_window()
+
+call fill_window()
+
+
+! allocate and fill a local buffer to transfer
+! data into.  make sure the buffer has the original
+! contents before the transfer.
+
+call prefill_target()
+
+call check_data_before()
+
+
+! first test - have each task get 10 items from 
+! task 0 at offset 100 into the task 0 window 
+
+owner_task = 0
+window_offset = 100
+
+call get_data(owner_task, window_offset, target_count, target_array)
+
+call check_data_after()
+
+
+! now have each task get data from the previous task.
+! wrap around for task 0.  also set different offsets
+! in the window for each atsk
+
+owner_task = myrank - 1
+if (owner_task < 0) owner_task = total_tasks - 1
+window_offset = myrank + 1
+
+call get_data(owner_task, window_offset, target_count, target_array)
+
+call check_data_after()
+
+
+! release resources
+
+call free_window()
+
+
+call takedown_mpi()
+
+! end of main program
+
+contains
+
+!-------------------------------------------------------------
+! allocate an array on each task and make it available to
+! other tasks by creating a window with it.
+
+subroutine create_window()
+
+   integer :: bytesize  ! size in bytes of each item in the window
+
+   call MPI_Type_Size(datasize, bytesize, ierror)
+   if (ierror /= MPI_SUCCESS) then
+      print *, "MPI_Type_Size() did not succeed, error code = ", ierror
+      stop
+   endif
+   
+   allocate(contiguous_array(window_items))
+   contiguous_array = myrank
+   
+   window_size = window_items * bytesize
+   
+   ! Expose local memory to RMA operation by other processes in a communicator.
+   call MPI_Win_Create(contiguous_array, window_size, bytesize, MPI_INFO_NULL, &
+                       MPI_COMM_WORLD, our_window, ierror)
+   if (ierror /= MPI_SUCCESS) then
+      print *, "MPI_Win_Create() did not succeed, error code = ", ierror
+      stop
+   endif
+
+end subroutine create_window
+
+!-------------------------------------------------------------
+! release the window, and deallocate arrays
+
+subroutine free_window()
+
+   call MPI_Win_Free(our_window, ierror)
+   if (ierror /= MPI_SUCCESS) then
+      print *, "MPI_Win_Free() did not succeed, error code = ", ierror
+      stop
+   endif
+
+   deallocate(contiguous_array)
+   deallocate(target_array)
+
+end subroutine free_window
+
+!-------------------------------------------------------------
+! each task fills its local window with unique values of the
+! form 1,00x,00y where x is the task number and y is the offset
+! into the array.  
+
+subroutine fill_window()
+
+   integer :: i, base
+   
+   base = 1000000 + (myrank * 1000)
+   do i=1, window_items
+      contiguous_array(i) = base + i
+   enddo
+
+end subroutine fill_window
+
+!-------------------------------------------------------------
+! this is the MPI one-sided communication call.  each task
+! gets wcount items, starting at an offset windex into the
+! remote task's window, and puts the data into local array x.
+
+subroutine get_data(owner, windex, wcount, x)
+
+   integer,  intent(in)  :: owner    ! task that owns the window to copy from
+   integer(MPI_OFFSET_KIND), intent(in)  :: windex   ! index into the owning task's window
+   integer,  intent(in)  :: wcount   ! how many items to transfer
+   real(r8), intent(out) :: x(:)     ! result
+   
+   ! Note to programmer: The data transfer is not guaranteed
+   ! to have occured until the call to MPI_Win_Unlock.
+   ! => Don't do anything with target inbetween MPI_Get and MPI_Win_Lock
+   
+   call MPI_Win_Lock(MPI_LOCK_SHARED, owner, 0, our_window, ierror)
+   if (ierror /= MPI_SUCCESS) then
+      print *, "MPI_Win_Lock() did not succeed, error code = ", ierror
+      stop
+   endif
+   
+   call MPI_Get(x, wcount, datasize, owner, windex-1, wcount, datasize, our_window, ierror)
+   if (ierror /= MPI_SUCCESS) then
+      print *, "MPI_Get() did not succeed, error code = ", ierror
+      stop
+   endif
+   
+   call MPI_Win_Unlock(owner, our_window, ierror)
+   if (ierror /= MPI_SUCCESS) then
+      print *, "MPI_Win_Unlock() did not succeed, error code = ", ierror
+      stop
+   endif
+
+   if (verbose) print *, 'MPI_Get() returned on task ', myrank
+
+end subroutine get_data
+
+!-------------------------------------------------------------
+! allocate and fill the target array on each task so when
+! data is transferred it should overwrite these values.
+
+subroutine prefill_target()
+
+   integer :: i
+
+   allocate(target_array(target_count))
+
+   do i=1, target_count
+      target_array(i) = -i
+   enddo
+
+end subroutine prefill_target
+
+!-------------------------------------------------------------
+! make sure the local array has the initial values before
+! starting the data transfer
+
+subroutine check_data_before()
+
+   integer :: i
+
+   do i=1, target_count
+      if (target_array(i) /= -i) then
+         print *, "target array not initialized consistently on task ", myrank
+         print *, "index ", i, " is ", target_array(i), ", expected ", -i
+         stop
+      endif
+   enddo
+
+end subroutine check_data_before
+
+!-------------------------------------------------------------
+! after the one-sided communication, verify that the data
+! in the local array has changed.  a more exhaustive test
+! would only transfer part of the window into this buffer
+! and ensure only the right data changed and the rest 
+! remained fixed.
+
+subroutine check_data_after()
+
+   integer :: i, base, expected_val
+
+   base = 1000000 + (owner_task * 1000)
+
+   do i=1, target_count
+      expected_val = base + window_offset + i - 1
+      if (target_array(i) /= expected_val) then
+         print *, "one sided transfer results not as expected on task ", myrank
+         print *, "index ", i, " is ", target_array(i), ", expected ", expected_val
+         stop
+      endif
+   enddo
+
+   if (verbose) print *, 'data check succeeded on task ', myrank
+
+end subroutine check_data_after
+
+!-------------------------------------------------------------
+! standard mpi initialization
+
+subroutine setup_mpi()
+
+   ierror = -999
+   call MPI_Init(ierror)
+   if (ierror /= MPI_SUCCESS) then
+      print *, "MPI_Init() did not succeed, error code = ", ierror
+      print *, "If error code is -999, the most likely problem is that"
+      print *, "the right MPI libraries were not found at compile time."
+      stop
+   endif
+   
+   myrank = -1
+   call MPI_Comm_rank(MPI_COMM_WORLD, myrank, ierror)
+   if (ierror /= MPI_SUCCESS) then
+      print *, "MPI_Comm_rank() did not succeed, error code = ", ierror
+      stop
+   endif
+   
+   total_tasks = -1
+   call MPI_Comm_size(MPI_COMM_WORLD, total_tasks, ierror)
+   if (ierror /= MPI_SUCCESS) then
+      print *, "MPI_Comm_size() did not succeed, error code = ", ierror
+      stop
+   endif
+
+   if (verbose) print *, 'MPI initialized ok on task ', myrank
+
+end subroutine setup_mpi
+
+!-------------------------------------------------------------
+! shut down mpi.  wait here for all tasks to finish.
+
+subroutine takedown_mpi()
+
+   if (verbose) print *, "Ready to finalize MPI and end program on task ", myrank
+   
+   call MPI_Barrier(MPI_COMM_WORLD, ierror)
+   if (ierror /= MPI_SUCCESS) then
+      print *, "MPI_Barrier() did not succeed, error code = ", ierror
+      stop
+   endif
+   
+   if (myrank == 0) print *, 'Test succeeded'
+   
+   call MPI_Finalize(ierror)
+   if (ierror /= MPI_SUCCESS) then
+      print *, "MPI_Finalize() did not succeed, error code = ", ierror
+      stop
+   endif
+   
+   ! shouldn't print after finalize called; hangs on some MPI implementations
+
+end subroutine takedown_mpi
+
+!-------------------------------------------------------------
+! 
+! the terminology here is a bit confusing.  
+! "origin" is the local buffer and offset where the data will be put, so it
+! is the destination.
+!
+! "target" refers to the remote task rank and offset into the source buffer.
+!
+! args to MPI_Get():
+! origin_addr
+!  Initial address of origin buffer (choice).
+! origin_count
+!  Number of entries in origin buffer (nonnegative integer).
+! origin_datatype
+!  Data type of each entry in origin buffer (handle).
+! target_rank
+!  Rank of target (nonnegative integer).
+! target_disp
+!  Displacement from window start to the beginning of the target buffer (nonnegative integer).
+! target_count
+!  Number of entries in target buffer (nonnegative integer).
+! target datatype
+!  datatype of each entry in target buffer (handle)
+! win
+!  window object used for communication (handle)
+! ierror
+!  Error status (integer).
+! 
+!-------------------------------------------------------------
+
+
+end program ftest_onesided
+

--- a/developer_tests/mpi_utilities/tests/ftest_sendrecv.f90
+++ b/developer_tests/mpi_utilities/tests/ftest_sendrecv.f90
@@ -1,24 +1,20 @@
 ! DART software - Copyright UCAR. This open source software is provided
 ! by UCAR, "as is", without charge, subject to all terms of use at
 ! http://www.image.ucar.edu/DAReS/DART/DART_download
-!
-! $Id$
 
 program ftest_sendrecv
 
-! simple MPI fortran program.  use to test running interactively
-! with MPI parallel communication libraries.  warning -- this program
-! may compile without obvious errors, but at runtime, unless MPI_Init()
-! returns 0 as the error code, there is a good chance the compile and
-! link phase did not succeed.
+! MPI fortran program that uses parts of the DART library to test
+! the send and receive functions in the mpi_utilities_mod.f90 file.
+! THIS IS NOT A STANDALONE PROGRAM!
 
 ! The following 2 build tips are the 2 places where different installations
 ! of MPI seem to vary the most.  Some systems have an include file, some
 ! have a F90 module.  Some require an interface block to use the system()
 ! function, some give an error if it is here.   You can use this program
-! to figure out which combinations work on your system.  Then go into the
-! $DART/mpi_utilities and make the same two changes in mpi_utilities_mod.f90,
-! and just the system() change (if needed) in null_mpi_utilities_mod.f90.
+! to figure out which combinations work on your system.  Then go into 
+! $DART/assimilation_code/utilities/mpi_utilities_mod.f90 and make the 
+! same two changes there. also possibly (if needed) null_mpi_utilities_mod.f90.
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ! BUILD TIP 1:
@@ -27,6 +23,8 @@ program ftest_sendrecv
 ! file which defines constants.  Try to use the module if it is available.
 
 use mpi
+
+! these are DART modules which must be built before running this test.
 use types_mod
 use utilities_mod
 use time_manager_mod
@@ -47,14 +45,15 @@ implicit none
 ! you an error about an undefined symbol (something like '_system_').  
 ! Comment this block in or out as needed.
 
-! ! interface block for getting return code back from system() routine
-! interface
-!  function system(string)
-!   character(len=*) :: string
-!   integer :: system
-!  end function system
-! end interface
-! ! end block
+! interface block for getting return code back from system() routine
+ !!SYSTEM_BLOCK_EDIT START COMMENTED_IN
+   interface
+    function system(string)
+     character(len=*) :: string
+     integer :: system
+    end function system
+   end interface
+ !!SYSTEM_BLOCK_EDIT END COMMENTED_IN
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
@@ -64,7 +63,7 @@ real(r8) :: buf(BSIZE)
 integer :: i
 
 ! integer variables
-integer :: ierror, myrank, totalprocs, rc
+integer :: myrank, totalprocs
 
    call initialize_mpi_utilities('ftest_sendrecv')
 
@@ -93,8 +92,3 @@ integer :: ierror, myrank, totalprocs, rc
 
 end program ftest_sendrecv
 
-! <next few lines under version control, do not edit>
-! $URL$
-! $Id$
-! $Revision$
-! $Date$

--- a/developer_tests/mpi_utilities/tests/ftest_stop.f90
+++ b/developer_tests/mpi_utilities/tests/ftest_stop.f90
@@ -1,8 +1,6 @@
 ! DART software - Copyright UCAR. This open source software is provided
 ! by UCAR, "as is", without charge, subject to all terms of use at
 ! http://www.image.ucar.edu/DAReS/DART/DART_download
-!
-! $Id$
 
 program ftest_stop
 
@@ -45,14 +43,15 @@ implicit none
 ! you an error about an undefined symbol (something like '_system_').  
 ! Comment this block in or out as needed.
 
-!  ! interface block for getting return code back from system() routine
-!  interface
-!   function system(string)
-!    character(len=*) :: string
-!    integer :: system
-!   end function system
-!  end interface
-!  ! end block
+! interface block for getting return code back from system() routine
+ !!SYSTEM_BLOCK_EDIT START COMMENTED_IN
+   interface
+    function system(string)
+     character(len=*) :: string
+     integer :: system
+    end function system
+   end interface
+ !!SYSTEM_BLOCK_EDIT END COMMENTED_IN
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! 
 
@@ -189,8 +188,3 @@ end subroutine restart_task
 
 end program ftest_stop
 
-! <next few lines under version control, do not edit>
-! $URL$
-! $Id$
-! $Revision$
-! $Date$


### PR DESCRIPTION
## Description:
<!--- Describe your changes -->
Add a new MPI one-sided test to verify MPI is working correctly.   Update other tests to use the standard 'system' block formatting, add a version of fixsystem here.  Add new test to Makefile and update it.  Update the README to fix directory names, contact info, add ftest_onesided info.

i also have some minor non-code changing updates to other files in this dir.  Will commit them separately later.

### Fixes issue
<!--- link to github issue(s) -->
Currently there is a user report of problems with one-sided communication.  This standalone test should verify that the one-sided MPI functions work.  (Even if MPI works, sometimes there are ways for one-sided to break.)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ x] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ x] My change requires a change to the documentation.
  - [x ] I have updated the documentation accordingly.

### Tests
Built and ran in this directory on cheyenne compute node (needed for MPI0 with intel and gfortran.

## Checklist for merging

- [ ] Updated changelog entry
- [ x] Documentation updated
- [ ] Version tag 

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [ x] No dataset needed
