### PR TITLE
bug-fix: add declaration for STAT function

### DIFF
--- a/observations/obs_converters/NCEP/prep_bufr/convert_bufr/grabbufr.f
+++ b/observations/obs_converters/NCEP/prep_bufr/convert_bufr/grabbufr.f
@@ -54,6 +54,7 @@ C$$$
       INTEGER(4)       narg,iargc,JSTAT(100)
       integer findbufr, i, INDEXVAL, rc
       character*1 byte(8)
+      integer :: STAT
  
       data i1/11/,i2/51/,newed/2/
 

--- a/observations/obs_converters/NCEP/prep_bufr/convert_bufr/stat_test.f
+++ b/observations/obs_converters/NCEP/prep_bufr/convert_bufr/stat_test.f
@@ -54,6 +54,7 @@ C$$$
       CHARACTER(len=80) :: infile
       INTEGER(4)        :: narg,iargc,JSTAT(100)
       integer           :: i, KBYTES, rc
+      integer           :: STAT
 
 C
 c liu 03/16/2005


### PR DESCRIPTION
## Description:
<!--- Describe your changes -->
Added a declaration for the STAT function to grabbufr.f and stat_test.f
Without the declaration, when using the PGI compiler you get the following error for long(ish) filenames 
e.g.  prepqm20012912.no_ship_id
ERROR IN FUNCTION STAT GETTING FILE INFO, RC =   -2147483648

### Fixes issue
<!--- link to github issue(s) -->
#256

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

### Tests
Please describe any tests you ran to verify your changes.

Compared grabbufr on 8 buffer files.  The files are here:
/glade/scratch/hkershaw/DART/Bugs/bug_256/test_many

PGI, intel, gfortran.  Results are identical to using grabbufr built with `install.sh` from the main branch.  However see note in issue #256 on the main branch -O changes the results.  I think this is a bug not a feature. 

stat_test used to check long filenames. 

## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Version tag 

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [x] Dataset download instructions included
- [ ] No dataset needed
