### PR TITLE
bug-fix: Obs_seq_to_netcdf appending files 

### DIFF
--- a/assimilation_code/programs/obs_seq_to_netcdf/obs_seq_to_netcdf.f90
+++ b/assimilation_code/programs/obs_seq_to_netcdf/obs_seq_to_netcdf.f90
@@ -130,6 +130,8 @@ integer  :: iepoch, ifile, num_obs_in_epoch, ngood
 
 integer  :: i, io, obsindex, ncunit
 integer  :: Nepochs
+! Keep track of epoch files created during this run of obs_seq_to_netcdf
+logical, allocatable, dimension(:) :: epoch_file_created 
 
 type(schedule_type) :: schedule
 type(time_type) :: TimeMin, TimeMax    ! of the entire period of interest
@@ -198,6 +200,8 @@ Nepochs = get_schedule_length(schedule)
 
 allocate(total_obs_in_epoch(Nepochs))
 total_obs_in_epoch = 0
+allocate(epoch_file_created(Nepochs))
+epoch_file_created(:) = .false.
 
 call get_time_from_schedule(TimeMin, schedule,       1, 1)
 call get_time_from_schedule(TimeMax, schedule, Nepochs, 2)
@@ -444,8 +448,14 @@ ObsFileLoop : do ifile=1, size(obs_seq_filenames)
 
       if ( file_exist(ncName) .and. append_to_netcdf ) then
          ncunit = NC_Compatibility_Check(ncName, iepoch)
-      else
-         ncunit = InitNetCDF(ncName, iepoch)
+      else 
+         if (.not. epoch_file_created(iepoch)) then
+            write(*,*) 'creating file ', ncName
+            ncunit = InitNetCDF(ncName, iepoch)
+            epoch_file_created(iepoch) = .true.
+         else
+            ncunit = NC_Compatibility_Check(ncName, iepoch)
+         endif
       endif
 
       ngood = 0
@@ -576,6 +586,7 @@ if (allocated(module_obs_copy_names)) &
    deallocate(module_obs_copy_names, module_qc_copy_names)
 
 deallocate(obs_seq_filenames)
+deallocate(epoch_file_created)
 
 call error_handler(E_MSG,'obs_seq_to_netcdf','Finished successfully.',source)
 call finalize_utilities()

--- a/assimilation_code/programs/obs_seq_to_netcdf/obs_seq_to_netcdf.f90
+++ b/assimilation_code/programs/obs_seq_to_netcdf/obs_seq_to_netcdf.f90
@@ -450,7 +450,8 @@ ObsFileLoop : do ifile=1, size(obs_seq_filenames)
          ncunit = NC_Compatibility_Check(ncName, iepoch)
       else 
          if (.not. epoch_file_created(iepoch)) then
-            write(*,*) 'creating file ', ncName
+            write(string1,*) 'creating file ', ncName
+            call error_handler(E_MSG,'obs_seq_to_netcdf',string1,source)
             ncunit = InitNetCDF(ncName, iepoch)
             epoch_file_created(iepoch) = .true.
          else

--- a/assimilation_code/programs/obs_seq_to_netcdf/radiance_obs/obs_seq_to_netcdf.f90
+++ b/assimilation_code/programs/obs_seq_to_netcdf/radiance_obs/obs_seq_to_netcdf.f90
@@ -148,6 +148,8 @@ integer  :: iepoch, ifile, num_obs_in_epoch, ngood
 
 integer  :: i, io, obsindex, ncunit
 integer  :: Nepochs
+! Keep track of epoch files created during this run of obs_seq_to_netcdf
+logical, allocatable, dimension(:) :: epoch_file_created 
 
 type(schedule_type) :: schedule
 type(time_type) :: TimeMin, TimeMax    ! of the entire period of interest
@@ -216,6 +218,8 @@ Nepochs = get_schedule_length(schedule)
 
 allocate(total_obs_in_epoch(Nepochs))
 total_obs_in_epoch = 0
+allocate(epoch_file_created(Nepochs))
+epoch_file_created(:) = .false.
 
 call get_time_from_schedule(TimeMin, schedule,       1, 1)
 call get_time_from_schedule(TimeMax, schedule, Nepochs, 2)
@@ -464,8 +468,13 @@ ObsFileLoop : do ifile=1, size(obs_seq_filenames)
       if ( file_exist(ncName) .and. append_to_netcdf ) then
          ncunit = NC_Compatibility_Check(ncName, iepoch)
       else
-         ncunit = InitNetCDF(ncName, iepoch)
-         append_to_netcdf = .true.
+         if (.not. epoch_file_created(iepoch)) then
+            write(*,*) 'creating file ', ncName
+            ncunit = InitNetCDF(ncName, iepoch)
+            epoch_file_created(iepoch) = .true.
+         else
+            ncunit = NC_Compatibility_Check(ncName, iepoch)
+         endif
       endif
 
       ngood = 0
@@ -604,6 +613,7 @@ if (allocated(module_obs_copy_names)) &
    deallocate(module_obs_copy_names, module_qc_copy_names)
 
 deallocate(obs_seq_filenames)
+deallocate(epoch_file_created)
 
 call error_handler(E_MSG,'obs_seq_to_netcdf','Finished successfully.',source)
 call finalize_utilities()

--- a/assimilation_code/programs/obs_seq_to_netcdf/radiance_obs/obs_seq_to_netcdf.f90
+++ b/assimilation_code/programs/obs_seq_to_netcdf/radiance_obs/obs_seq_to_netcdf.f90
@@ -469,7 +469,8 @@ ObsFileLoop : do ifile=1, size(obs_seq_filenames)
          ncunit = NC_Compatibility_Check(ncName, iepoch)
       else
          if (.not. epoch_file_created(iepoch)) then
-            write(*,*) 'creating file ', ncName
+            write(string1,*) 'creating file ', ncName
+            call error_handler(E_MSG,'obs_seq_to_netcdf',string1,source)
             ncunit = InitNetCDF(ncName, iepoch)
             epoch_file_created(iepoch) = .true.
          else


### PR DESCRIPTION
## Description:
<!--- Describe your changes -->
Added logic to obs_seq_to_netcdf to keep track of whether a files has been created for an epoch during that run of obs_seq_to_netcdf.  Previously if there were multiple obs_sequence files in an epoch, the epoch file was being created afresh for each obs_seq file. Thus, only obs from the last file in the list were present in obs_epoch.nc 

### Fixes issue
<!--- link to github issue(s) -->
#12 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

### Tests
Please describe any tests you ran to verify your changes.

Epochs set for 1 day long for the month of February:

```
&schedule_nml
   calendar             = 'Gregorian'
   first_bin_start      =  2012,  2,  1,  0,  0,  0
   first_bin_end        =  2012,  2,  2,  0,  0,  0
   last_bin_end         =  2012,  3,  1,  0,  0,  0
   bin_interval_days    = 1 
   bin_interval_seconds = 0 
   max_num_bins         = 31  
   print_table          = .true.
   /   
```

List of obs_sequence files with multiple obs sequences in epoch Feb 5th.

```
obs_seq.2012-02-05-21600
obs_seq.2012-02-05-43200
obs_seq.2012-02-05-64800
obs_seq.2012-02-13-21600
obs_seq.2012-02-29-64800
````

check number of obs in epoch files match sum from obs_seq files. 
obs_epoch_005.nc
obs_epoch_013.nc
obs_epoch_029,nc


## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Version tag 

## Testing Datasets

- [x] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [ ] No dataset needed
