### PR TITLE
Model size i8 fix for state vector io and mpi_utilities

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,13 @@ individual files.
 
 The changes are now listed with the most recent at the top.
 
+**September 30 2021 :: Bug fix for very large models. Tag v9.11.11**
+
+- mpi_utilties_mod using correct check for message length > SNDRCV_MAXSIZE
+- new developers test for large message sizes
+- State vector IO updated to use i8 for state indexing
+- WRF model_mod now using i8  
+
 **September 21 2021 :: Bug fix for perfect_model_obs. Tag v9.11.10**
 
 - perfect_model_obs now exits cleanly when no filenames are given

--- a/assimilation_code/modules/io/direct_netcdf_mod.f90
+++ b/assimilation_code/modules/io/direct_netcdf_mod.f90
@@ -835,8 +835,8 @@ integer,  intent(in)    :: end_var
 integer,  intent(in)    :: domain
 
 integer :: i
-integer :: istart, iend
-integer :: var_size
+integer(i8) :: istart, iend
+integer(i8) :: var_size
 integer, allocatable :: dims(:)
 integer :: ret, var_id
 

--- a/assimilation_code/modules/io/direct_netcdf_mod.f90
+++ b/assimilation_code/modules/io/direct_netcdf_mod.f90
@@ -166,7 +166,7 @@ subroutine read_transpose(state_ens_handle, name_handle, domain, dart_index, rea
 type(ensemble_type),       intent(inout) :: state_ens_handle !< Ensemble handle
 type(stage_metadata_type), intent(in)    :: name_handle      !< Name handle
 integer,                   intent(in)    :: domain           !< Which domain to read
-integer,                   intent(inout) :: dart_index       !< This is for multiple domains
+integer(i8),               intent(inout) :: dart_index       !< This is for multiple domains
 logical,                   intent(in)    :: read_single_vars !< Read one variable at a time
 
 if (task_count() == 1) then
@@ -188,7 +188,7 @@ subroutine transpose_write(state_ens_handle, name_handle, domain, &
 type(ensemble_type),       intent(inout) :: state_ens_handle
 type(stage_metadata_type), intent(in)    :: name_handle
 integer,                   intent(in)    :: domain
-integer,                   intent(inout) :: dart_index
+integer(i8),               intent(inout) :: dart_index
 logical,                   intent(in)    :: write_single_vars !< write one variable at a time
 logical,                   intent(in)    :: write_single_precision
 
@@ -885,14 +885,15 @@ subroutine read_transpose_single_task(state_ens_handle, name_handle, domain, dar
 type(ensemble_type),      intent(inout) :: state_ens_handle
 type(stage_metadata_type), intent(in)   :: name_handle
 integer,                   intent(in)   :: domain
-integer,                  intent(inout) :: dart_index !< This is for multiple domains
+integer(i8),              intent(inout) :: dart_index !< This is for multiple domains
 
 real(r8), allocatable :: vector(:)
 
 integer :: ncfile !< netcdf input file identifier
 character(len=256) :: netcdf_filename
 
-integer :: block_size , istart, iend , copy , start_var
+integer(i8) :: block_size, istart, iend
+integer :: copy , start_var
 
 istart     = dart_index ! position in state_ens_handle%vars
 block_size = 0
@@ -946,7 +947,7 @@ subroutine transpose_write_single_task(state_ens_handle, name_handle, domain, &
 type(ensemble_type),       intent(inout) :: state_ens_handle
 type(stage_metadata_type), intent(in)    :: name_handle
 integer,                   intent(in)    :: domain
-integer,                   intent(inout) :: dart_index
+integer(i8),               intent(inout) :: dart_index
 logical,                   intent(in)    :: write_single_precision
 
 ! netcdf variables
@@ -955,7 +956,8 @@ character(len=256) :: netcdf_filename_out
 
 real(r8), allocatable :: vector(:)
 
-integer :: block_size , istart, iend , copy , start_var, end_var
+integer(i8) :: block_size , istart, iend
+integer :: copy , start_var, end_var
 integer :: time_owner, time_owner_index
 logical :: clamp_vars, force_copy
 type(time_type) :: dart_time
@@ -1052,7 +1054,7 @@ subroutine read_transpose_multi_task(state_ens_handle, name_handle, domain, &
 type(ensemble_type),       intent(inout) :: state_ens_handle
 type(stage_metadata_type), intent(in)    :: name_handle
 integer,                   intent(in)    :: domain
-integer,                   intent(inout) :: dart_index !< This is for multiple domains
+integer(i8),               intent(inout) :: dart_index !< This is for multiple domains
 logical,                   intent(in)    :: read_var_by_var !< Read one variable at a time 
 
 integer :: start_var, end_var   !< start/end variables in a read block
@@ -1060,15 +1062,15 @@ integer :: start_rank           !< starting rank containg variable of interest
 integer :: recv_start, recv_end !< start/end variables for receives
 integer :: send_start, send_end !< start/end variables for sends
 integer :: recv_pe, sending_pe  !< PEs sending and receiving data
-integer :: elm_count            !< number of elements to send
-integer :: block_size           !< number of state elements in a block
-integer :: istart, iend         !< position in state vector copies array
+integer(i8) :: elm_count        !< number of elements to send
+integer(i8) :: block_size       !< number of state elements in a block
+integer(i8) :: istart, iend     !< position in state vector copies array
 integer :: ens_size             !< ensemble size
 integer :: my_pe                !< task or pe?
 integer :: ensemble_member      !< the ensmeble_member you are receiving.
 integer :: my_copy              !< which copy a pe is reading, from 1 to ens_handle%num_copies
 integer :: c                    !< copies_read loop index
-integer :: start_point
+integer(i8) :: start_point
 integer :: copies_read
 integer :: num_state_variables
 integer :: dummy_loop
@@ -1234,7 +1236,7 @@ subroutine transpose_write_multi_task(state_ens_handle, name_handle, domain, &
 type(ensemble_type),       intent(inout) :: state_ens_handle
 type(stage_metadata_type), intent(in)    :: name_handle
 integer,                   intent(in)    :: domain
-integer,                   intent(inout) :: dart_index
+integer(i8),               intent(inout) :: dart_index
 logical,                   intent(in)    :: write_var_by_var !< Write a single variable, one at a time
 logical,                   intent(in)    :: write_single_precision
 
@@ -1243,10 +1245,10 @@ integer :: start_var, end_var !< start/end variables in a read block
 integer :: my_pe !< task or pe?
 integer :: recv_pe, sending_pe
 real(r8), allocatable :: var_block(:) !< for reading in variables
-integer :: block_size !< number of variables in a block
-integer :: elm_count !< number of elements to send
-integer :: istart!< position in state_ens_handle%copies
-integer :: iend
+integer(i8) :: block_size !< number of variables in a block
+integer(i8) :: elm_count !< number of elements to send
+integer(i8) :: istart!< position in state_ens_handle%copies
+integer(i8) :: iend
 integer :: ens_size !< ensemble size
 integer :: start_rank
 integer :: recv_start, recv_end
@@ -1517,8 +1519,8 @@ integer,  intent(in)    :: domain
 logical,  intent(in)    :: do_file_clamping
 logical,  intent(in)    :: force_copy
 
-integer :: istart, iend
-integer :: i, ret, var_id, var_size
+integer(i8) :: istart, iend, var_size
+integer :: i, ret, var_id
 integer, allocatable :: dims(:)
 
 logical :: missing_possible
@@ -2195,7 +2197,7 @@ integer,                intent(in) :: timeindex
 
 integer, dimension(NF90_MAX_VAR_DIMS) :: dim_lengths
 integer, dimension(NF90_MAX_VAR_DIMS) :: start_point
-integer :: istart, iend
+integer(i8) :: istart, iend
 integer :: ivar, jdim
 integer :: ndims
 integer :: ret ! netcdf return code

--- a/assimilation_code/modules/io/direct_netcdf_mod.f90
+++ b/assimilation_code/modules/io/direct_netcdf_mod.f90
@@ -2951,7 +2951,7 @@ integer, intent(in) :: pe
 integer, intent(in) :: start_rank
 integer(i8), intent(in) :: block_size
 
-integer :: elm_count, remainder
+integer(i8) :: elm_count, remainder
 
 elm_count = block_size/task_count()
 remainder = mod(block_size, task_count())
@@ -2989,7 +2989,7 @@ function find_start_point(recv_pe, start_rank)
 
 integer, intent(in)  :: recv_pe !< the receiver
 integer, intent(in)  :: start_rank !< the pe that owns the 1st element of the var_block
-integer(i8)          :: find_start_point
+integer              :: find_start_point
 
 if (start_rank < recv_pe) then
    find_start_point = recv_pe - start_rank + 1

--- a/assimilation_code/modules/io/direct_netcdf_mod.f90
+++ b/assimilation_code/modules/io/direct_netcdf_mod.f90
@@ -484,10 +484,11 @@ integer, dimension(NF90_MAX_VAR_DIMS) :: dim_lengths
 integer, dimension(NF90_MAX_VAR_DIMS) :: dim_start_point
 
 integer :: icopy, ivar, domain  
-integer :: ens_size, extra_size, time_size, var_size, elm_count, ndims
+integer :: ens_size, extra_size, time_size, ndims
 integer :: my_pe, recv_pe, recv_start, recv_end, start_rank
-integer :: start_pos, end_pos, send_start, send_end, start_point
+integer :: send_start, send_end
 logical :: do_perturb, is_sender, is_receiver, is_extra_copy
+integer(i8) :: var_size, elm_count, start_pos, end_pos, start_point
 
 real(r8), allocatable :: var_block(:)
 
@@ -1240,7 +1241,7 @@ integer(i8),               intent(inout) :: dart_index
 logical,                   intent(in)    :: write_var_by_var !< Write a single variable, one at a time
 logical,                   intent(in)    :: write_single_precision
 
-integer :: i
+integer(i8) :: i
 integer :: start_var, end_var !< start/end variables in a read block
 integer :: my_pe !< task or pe?
 integer :: recv_pe, sending_pe
@@ -2040,9 +2041,9 @@ subroutine send_to_waiting_task(state_ens_handle, recv_pe, start, elm_count, blo
 
 type(ensemble_type), intent(in) :: state_ens_handle
 integer,             intent(in) :: recv_pe ! receiving pe
-integer,             intent(in) :: start ! start in variable block on sender.
-integer,             intent(in) :: elm_count ! how many elements
-integer,             intent(in) :: block_size ! size of info on sender - the receiver only
+integer(i8),         intent(in) :: start ! start in variable block on sender.
+integer(i8),         intent(in) :: elm_count ! how many elements
+integer(i8),         intent(in) :: block_size ! size of info on sender - the receiver only
                                               ! gets part of this.
 real(r8),            intent(in) :: variable_block(block_size) ! variable info
 
@@ -2084,8 +2085,8 @@ subroutine send_variables_to_write(state_ens_handle, recv_pe, &
 type(ensemble_type), intent(in) :: state_ens_handle
 integer,             intent(in) :: recv_pe ! receiving pe
 integer,             intent(in) :: ensemble_member
-integer,             intent(in) :: start  ! start in copies array on sender.
-integer,             intent(in) :: finish ! end in copies array on sender
+integer(i8),         intent(in) :: start  ! start in copies array on sender.
+integer(i8),         intent(in) :: finish ! end in copies array on sender
 
 real(r8), allocatable :: buffer(:) ! for making send array contiguous
 
@@ -2122,8 +2123,8 @@ subroutine wait_to_receive(state_ens_handle, recv_pe, &
 type(ensemble_type), intent(inout) :: state_ens_handle
 integer,             intent(in)    :: recv_pe ! receiving pe
 integer,             intent(in)    :: ensemble_member
-integer,             intent(in)    :: start  ! start in copies array on sender.
-integer,             intent(in)    :: finish ! end in copies array on sender
+integer(i8),         intent(in)    :: start  ! start in copies array on sender.
+integer(i8),         intent(in)    :: finish ! end in copies array on sender
 
 real(r8), allocatable :: buffer(:) ! for making send array contiguous
 
@@ -2159,9 +2160,9 @@ subroutine recv_variables_to_write(state_ens_handle, sending_pe, start, &
 
 type(ensemble_type), intent(in)    :: state_ens_handle
 integer,             intent(in)    :: sending_pe !! sending_pe
-integer,             intent(in)    :: start      !! start in vars array on receiver.
-integer,             intent(in)    :: elm_count  !! how many elements
-integer,             intent(in)    :: block_size !! size of info on sender - the receiver only gets part of this.
+integer(i8),         intent(in)    :: start      !! start in vars array on receiver.
+integer(i8),         intent(in)    :: elm_count  !! how many elements
+integer(i8),         intent(in)    :: block_size !! size of info on sender - the receiver only gets part of this.
 real(r8),            intent(inout) :: variable_block(block_size) !! variable info
 
 real(r8), allocatable :: buffer(:) !! for making send array contiguous
@@ -2948,7 +2949,7 @@ function num_elements_on_pe(pe, start_rank, block_size) result(elm_count)
 
 integer, intent(in) :: pe
 integer, intent(in) :: start_rank
-integer, intent(in) :: block_size
+integer(i8), intent(in) :: block_size
 
 integer :: elm_count, remainder
 
@@ -2988,7 +2989,7 @@ function find_start_point(recv_pe, start_rank)
 
 integer, intent(in)  :: recv_pe !< the receiver
 integer, intent(in)  :: start_rank !< the pe that owns the 1st element of the var_block
-integer              :: find_start_point
+integer(i8)          :: find_start_point
 
 if (start_rank < recv_pe) then
    find_start_point = recv_pe - start_rank + 1

--- a/assimilation_code/modules/io/state_structure_mod.f90
+++ b/assimilation_code/modules/io/state_structure_mod.f90
@@ -1547,7 +1547,7 @@ integer, intent(in) :: dom_id ! domain identifier
 
 integer :: ivar, jdim
 integer :: num_vars, num_dims, variable_size
-integer(i8) :: next_start, count_dims
+integer(i8) :: next_start
 integer :: count_dims
 integer(i8) :: domain_offset
 

--- a/assimilation_code/modules/io/state_structure_mod.f90
+++ b/assimilation_code/modules/io/state_structure_mod.f90
@@ -411,7 +411,7 @@ function add_domain_blank(domain_size) result(dom_id)
 integer(i8), intent(in) :: domain_size
 integer :: dom_id
 
-integer :: domain_offset
+integer(i8) :: domain_offset
 
 ! add to domains
 call assert_below_max_num_domains('add_domain_blank')
@@ -1391,7 +1391,8 @@ integer, intent(in) :: iloc, jloc, kloc
 integer, intent(in) :: dom_id, var_id
 integer(i8)         :: get_dart_vector_index
 
-integer :: ndims, offset
+integer :: ndims
+integer(i8) :: offset
 integer :: dsize(NF90_MAX_VAR_DIMS)
 
 ndims = get_num_dims(dom_id, var_id)
@@ -1546,7 +1547,8 @@ integer, intent(in) :: dom_id ! domain identifier
 
 integer :: ivar, jdim
 integer :: num_vars, num_dims, variable_size
-integer :: next_start, count_dims
+integer(i8) :: next_start, count_dims
+integer :: count_dims
 integer(i8) :: domain_offset
 
 if ( state%domain(dom_id)%method /= 'spec') then

--- a/assimilation_code/modules/io/state_vector_io_mod.f90
+++ b/assimilation_code/modules/io/state_vector_io_mod.f90
@@ -275,7 +275,7 @@ type(file_info_type), intent(in)    :: file_info
 logical,              intent(in)    :: use_time_from_file
 type(time_type),      intent(inout) :: model_time
 
-integer :: dart_index ! where to start in state_ens_handle%copies
+integer(i8) :: dart_index ! where to start in state_ens_handle%copies
 integer :: domain
 type(stage_metadata_type) :: restart_files
 
@@ -313,7 +313,7 @@ subroutine write_restart_direct(state_ens_handle, file_name_handle)
 type(ensemble_type),    intent(inout) :: state_ens_handle
 type(stage_metadata_type), intent(in) :: file_name_handle
 
-integer :: dart_index !< where to start in state_ens_handle%copies
+integer(i8) :: dart_index !< where to start in state_ens_handle%copies
 integer :: domain !< loop index
 
 if ( .not. module_initialized ) call state_vector_io_init() ! to read the namelist

--- a/assimilation_code/modules/utilities/ensemble_manager_mod.f90
+++ b/assimilation_code/modules/utilities/ensemble_manager_mod.f90
@@ -712,6 +712,17 @@ subroutine set_up_ens_distribution(ens_handle)
 type (ensemble_type),  intent(inout)  :: ens_handle
 
 integer :: num_per_pe_below, num_left_over, i
+integer(i8) :: per_pe, suggest_pes
+
+! Check that there are enough pes for the state
+per_pe = ens_handle%num_vars / num_pes
+if (per_pe >= (huge(i)-100) ) then
+   suggest_pes = ( ens_handle%num_vars / (huge(i)) ) * 2
+   write(msgstring, '(A,I5,X,A)') &
+   'not enough MPI tasks for the model size, suggest at least ' , &
+   suggest_pes, 'tasks'
+   call error_handler(E_ERR, 'set_up_ens_distribution', msgstring, source)
+endif
 
 ! Option 1: Maximum separation for both vars and copies
 ! Compute the total number of copies I'll get for var complete

--- a/assimilation_code/modules/utilities/ensemble_manager_mod.f90
+++ b/assimilation_code/modules/utilities/ensemble_manager_mod.f90
@@ -57,7 +57,7 @@ type ensemble_type
    !!!private
    integer(i8)                  :: num_vars
    integer                      :: num_copies, my_num_copies
-   integer(i8)                  :: my_num_vars
+   integer                      :: my_num_vars
    integer,        allocatable  :: my_copies(:)
    integer(i8),    allocatable  :: my_vars(:)
    ! Storage in next line is to be used when each pe has all copies of subset of vars
@@ -672,7 +672,7 @@ function get_my_num_vars(ens_handle)
 ! Returns the number of vars stored on my processor when copy complete.
 ! Same as num_vars if single process is in use.
 
-integer(i8)                      :: get_my_num_vars
+integer                          :: get_my_num_vars
 type (ensemble_type), intent(in) :: ens_handle
 
 get_my_num_vars = ens_handle%my_num_vars
@@ -712,7 +712,7 @@ subroutine set_up_ens_distribution(ens_handle)
 
 type (ensemble_type),  intent(inout)  :: ens_handle
 
-integer(i8) :: num_per_pe_below, num_left_over
+integer :: num_per_pe_below, num_left_over
 integer :: i
 
 ! Option 1: Maximum separation for both vars and copies
@@ -825,7 +825,7 @@ function get_max_num_vars(ens_handle, num_vars)
 
 type (ensemble_type), intent(in)  :: ens_handle
 integer(i8), intent(in) :: num_vars
-integer(i8)             :: get_max_num_vars
+integer                 :: get_max_num_vars
 !!!integer, intent(in) :: distribution_type
 
 !could this be instead:

--- a/assimilation_code/modules/utilities/ensemble_manager_mod.f90
+++ b/assimilation_code/modules/utilities/ensemble_manager_mod.f90
@@ -56,7 +56,8 @@ type ensemble_type
    !DIRECT ACCESS INTO STORAGE IS USED TO REDUCE COPYING: BE CAREFUL
    !!!private
    integer(i8)                  :: num_vars
-   integer                      :: num_copies, my_num_copies, my_num_vars
+   integer                      :: num_copies, my_num_copies
+   integer(i8)                  :: my_num_vars
    integer,        allocatable  :: my_copies(:)
    integer(i8),    allocatable  :: my_vars(:)
    ! Storage in next line is to be used when each pe has all copies of subset of vars

--- a/assimilation_code/modules/utilities/ensemble_manager_mod.f90
+++ b/assimilation_code/modules/utilities/ensemble_manager_mod.f90
@@ -672,7 +672,7 @@ function get_my_num_vars(ens_handle)
 ! Returns the number of vars stored on my processor when copy complete.
 ! Same as num_vars if single process is in use.
 
-integer                          :: get_my_num_vars
+integer(i8)                      :: get_my_num_vars
 type (ensemble_type), intent(in) :: ens_handle
 
 get_my_num_vars = ens_handle%my_num_vars
@@ -712,7 +712,8 @@ subroutine set_up_ens_distribution(ens_handle)
 
 type (ensemble_type),  intent(inout)  :: ens_handle
 
-integer :: num_per_pe_below, num_left_over, i
+integer(i8) :: num_per_pe_below, num_left_over
+integer :: i
 
 ! Option 1: Maximum separation for both vars and copies
 ! Compute the total number of copies I'll get for var complete
@@ -824,7 +825,7 @@ function get_max_num_vars(ens_handle, num_vars)
 
 type (ensemble_type), intent(in)  :: ens_handle
 integer(i8), intent(in) :: num_vars
-integer                 :: get_max_num_vars
+integer(i8)             :: get_max_num_vars
 !!!integer, intent(in) :: distribution_type
 
 !could this be instead:

--- a/assimilation_code/modules/utilities/ensemble_manager_mod.f90
+++ b/assimilation_code/modules/utilities/ensemble_manager_mod.f90
@@ -56,8 +56,7 @@ type ensemble_type
    !DIRECT ACCESS INTO STORAGE IS USED TO REDUCE COPYING: BE CAREFUL
    !!!private
    integer(i8)                  :: num_vars
-   integer                      :: num_copies, my_num_copies
-   integer                      :: my_num_vars
+   integer                      :: num_copies, my_num_copies, my_num_vars
    integer,        allocatable  :: my_copies(:)
    integer(i8),    allocatable  :: my_vars(:)
    ! Storage in next line is to be used when each pe has all copies of subset of vars
@@ -712,8 +711,7 @@ subroutine set_up_ens_distribution(ens_handle)
 
 type (ensemble_type),  intent(inout)  :: ens_handle
 
-integer :: num_per_pe_below, num_left_over
-integer :: i
+integer :: num_per_pe_below, num_left_over, i
 
 ! Option 1: Maximum separation for both vars and copies
 ! Compute the total number of copies I'll get for var complete

--- a/assimilation_code/programs/perfect_model_obs/perfect_model_obs.f90
+++ b/assimilation_code/programs/perfect_model_obs/perfect_model_obs.f90
@@ -638,17 +638,17 @@ end subroutine perfect_main
 
 subroutine perfect_initialize_modules_used()
 
-! Standard initialization (mpi not needed to use ensemble manager
-! since we are enforcing that this run as a single task).
+! Standard initialization
 call initialize_mpi_utilities('perfect_model_obs')
 
 ! Initialize modules used that require it
 
 ! Initialize the obs sequence module
 call static_init_obs_sequence()
+
 ! Initialize the model class data now that obs_sequence is all set up
 call static_init_assim_model()
-! Initialize the model class data now that obs_sequence is all set up
+
 call state_vector_io_init()
 call initialize_qc()
 

--- a/assimilation_code/programs/perfect_model_obs/perfect_model_obs.f90
+++ b/assimilation_code/programs/perfect_model_obs/perfect_model_obs.f90
@@ -262,6 +262,14 @@ has_cycling = single_file_out
 call parse_filenames(input_state_files,  input_filelist,  nfilesin)
 call parse_filenames(output_state_files, output_filelist, nfilesout)
 
+!> @todo FIXME  if nfilesout == 0 and write_output_state_to_file is .false.
+!> that shouldn't be an error.  if nfilesin == 0 and read_input_state_from_file
+!> is false, that also shouldn't be an error. 
+if (nfilesin == 0 .or. nfilesout == 0 ) then
+   msgstring = 'must specify both "input_state_files" and "output_state_files" in the namelist'
+   call error_handler(E_ERR,'perfect_main',msgstring,source)
+endif
+
 allocate(true_state_filelist(nfilesout))
 
 ! mutiple domains ( this is very unlikely to be the case, but in order to
@@ -273,15 +281,6 @@ if (nfilesout > 1) then
    enddo
 else
    true_state_filelist(1) = 'true_state.nc'
-endif
-
-!> @todo FIXME  if nfilesout == 0 and write_output_state_to_file is .false.
-!> that shouldn't be an error.  if nfilesin == 0 and read_input_state_from_file
-!> is false, that also shouldn't be an error.  (unless you're writing the mean
-!> and sd, and then maybe we should have a different name for output of input values.)
-if (nfilesin == 0 .or. nfilesout == 0 ) then
-   msgstring = 'must specify both "input_state_files" and "output_state_files" in the namelist'
-   call error_handler(E_ERR,'perfect_main',msgstring,source)
 endif
 
 call io_filenames_init(file_info_input,  1, cycling=has_cycling, single_file=single_file_in)
@@ -638,17 +637,17 @@ end subroutine perfect_main
 
 subroutine perfect_initialize_modules_used()
 
-! Standard initialization (mpi not needed to use ensemble manager
-! since we are enforcing that this run as a single task).
+! Standard initialization
 call initialize_mpi_utilities('perfect_model_obs')
 
 ! Initialize modules used that require it
 
 ! Initialize the obs sequence module
 call static_init_obs_sequence()
+
 ! Initialize the model class data now that obs_sequence is all set up
 call static_init_assim_model()
-! Initialize the model class data now that obs_sequence is all set up
+
 call state_vector_io_init()
 call initialize_qc()
 

--- a/assimilation_code/programs/perfect_model_obs/perfect_model_obs.f90
+++ b/assimilation_code/programs/perfect_model_obs/perfect_model_obs.f90
@@ -262,14 +262,6 @@ has_cycling = single_file_out
 call parse_filenames(input_state_files,  input_filelist,  nfilesin)
 call parse_filenames(output_state_files, output_filelist, nfilesout)
 
-!> @todo FIXME  if nfilesout == 0 and write_output_state_to_file is .false.
-!> that shouldn't be an error.  if nfilesin == 0 and read_input_state_from_file
-!> is false, that also shouldn't be an error. 
-if (nfilesin == 0 .or. nfilesout == 0 ) then
-   msgstring = 'must specify both "input_state_files" and "output_state_files" in the namelist'
-   call error_handler(E_ERR,'perfect_main',msgstring,source)
-endif
-
 allocate(true_state_filelist(nfilesout))
 
 ! mutiple domains ( this is very unlikely to be the case, but in order to
@@ -281,6 +273,15 @@ if (nfilesout > 1) then
    enddo
 else
    true_state_filelist(1) = 'true_state.nc'
+endif
+
+!> @todo FIXME  if nfilesout == 0 and write_output_state_to_file is .false.
+!> that shouldn't be an error.  if nfilesin == 0 and read_input_state_from_file
+!> is false, that also shouldn't be an error.  (unless you're writing the mean
+!> and sd, and then maybe we should have a different name for output of input values.)
+if (nfilesin == 0 .or. nfilesout == 0 ) then
+   msgstring = 'must specify both "input_state_files" and "output_state_files" in the namelist'
+   call error_handler(E_ERR,'perfect_main',msgstring,source)
 endif
 
 call io_filenames_init(file_info_input,  1, cycling=has_cycling, single_file=single_file_in)
@@ -637,17 +638,17 @@ end subroutine perfect_main
 
 subroutine perfect_initialize_modules_used()
 
-! Standard initialization
+! Standard initialization (mpi not needed to use ensemble manager
+! since we are enforcing that this run as a single task).
 call initialize_mpi_utilities('perfect_model_obs')
 
 ! Initialize modules used that require it
 
 ! Initialize the obs sequence module
 call static_init_obs_sequence()
-
 ! Initialize the model class data now that obs_sequence is all set up
 call static_init_assim_model()
-
+! Initialize the model class data now that obs_sequence is all set up
 call state_vector_io_init()
 call initialize_qc()
 

--- a/conf.py
+++ b/conf.py
@@ -21,7 +21,7 @@ copyright = '2021, University Corporation for Atmospheric Research'
 author = 'Data Assimilation Research Section'
 
 # The full version, including alpha/beta/rc tags
-release = '9.11.10'
+release = '9.11.11'
 master_doc = 'README'
 
 # -- General configuration ---------------------------------------------------

--- a/developer_tests/mpi_utilities/tests/Makefile
+++ b/developer_tests/mpi_utilities/tests/Makefile
@@ -100,6 +100,10 @@ ftest_mpi: fixsys ftest_mpi.f90
 ftest_sendrecv: ftest_sendrecv.f90 types_mod.o utilities_mod.o time_manager_mod.o mpi_utilities_mod.o
 	$(MPIFC) ftest_sendrecv.f90 types_mod.o utilities_mod.o time_manager_mod.o mpi_utilities_mod.o $(LDFLAGS) -o ftest_sendrecv
 
+# f90 test program for large messages (greater than 2^31-1 elements)
+ftest_sendrecv_big: ftest_sendrecv_big.f90 types_mod.o utilities_mod.o time_manager_mod.o mpi_utilities_mod.o
+	$(MPIFC) ftest_sendrecv_big.f90 types_mod.o utilities_mod.o time_manager_mod.o mpi_utilities_mod.o $(LDFLAGS) -o ftest_sendrecv_big 
+
 # test of MPI one-sided communication
 ftest_onesided: ftest_onesided.f90 
 	$(MPIFC) ftest_onesided.f90 $(LDFLAGS) -o ftest_onesided

--- a/developer_tests/mpi_utilities/tests/ftest_sendrecv_big.f90
+++ b/developer_tests/mpi_utilities/tests/ftest_sendrecv_big.f90
@@ -2,7 +2,7 @@
 ! by UCAR, "as is", without charge, subject to all terms of use at
 ! http://www.image.ucar.edu/DAReS/DART/DART_download
 
-program ftest_sendrecv
+program ftest_sendrecv_big
 
 ! MPI fortran program that uses parts of the DART library to test
 ! the send and receive functions in the mpi_utilities_mod.f90 file.
@@ -56,5 +56,5 @@ integer :: myrank, totalprocs
 
    call finalize_mpi_utilities()
 
-end program ftest_sendrecv
+end program ftest_sendrecv_big
 

--- a/developer_tests/mpi_utilities/tests/ftest_sendrecv_big.f90
+++ b/developer_tests/mpi_utilities/tests/ftest_sendrecv_big.f90
@@ -1,0 +1,60 @@
+! DART software - Copyright UCAR. This open source software is provided
+! by UCAR, "as is", without charge, subject to all terms of use at
+! http://www.image.ucar.edu/DAReS/DART/DART_download
+
+program ftest_sendrecv
+
+! MPI fortran program that uses parts of the DART library to test
+! the send and receive functions in the mpi_utilities_mod.f90 file.
+! THIS IS NOT A STANDALONE PROGRAM!
+
+
+! this module should be on your system if MPI is installed
+use mpi
+
+! these are DART modules which must be built before running this test.
+use types_mod
+use utilities_mod
+use time_manager_mod
+use mpi_utilities_mod
+
+implicit none
+
+! some older installations only installed a header file instead of
+! a module (module is better).  only if there is no other option,
+! comment out 'use mpi' above and comment in the include file here.
+!include "mpif.h"
+
+
+integer(i8), parameter :: BSIZE = 3350074489_i8
+
+real(r8), allocatable :: buf(:)
+
+! integer variables
+integer :: myrank, totalprocs
+
+   call initialize_mpi_utilities('ftest_sendrecv_big')
+
+   allocate(buf(BSIZE))
+   myrank = my_task_id()
+   print *, "My MPI rank is: ", myrank
+
+   totalprocs = task_count()
+   if (myrank == 0) print *, "Total MPI tasks: ", totalprocs
+   if (myrank == 0) print *, "Exchanging buffer of size ", size(buf, kind=i8), "between tasks 0 and 1"
+   if (myrank == 0) then
+      buf(:) = 1
+      call send_to(1, buf)
+   else if (myrank == 1) then
+      buf(:) = 0
+      call receive_from(0, buf)
+      if (any(buf == 0)) then
+         print *, 'NOT EVERYTHING WAS SENT'
+         stop
+      endif
+   endif
+
+   call finalize_mpi_utilities()
+
+end program ftest_sendrecv
+

--- a/developer_tests/mpi_utilities/tests/input.nml
+++ b/developer_tests/mpi_utilities/tests/input.nml
@@ -1,0 +1,6 @@
+&utilities_nml
+/
+
+&state_vector_io_nml
+  buffer_state_io = .true.
+/

--- a/developer_tests/mpi_utilities/tests/input.nml
+++ b/developer_tests/mpi_utilities/tests/input.nml
@@ -1,6 +1,3 @@
 &utilities_nml
 /
 
-&state_vector_io_nml
-  buffer_state_io = .true.
-/

--- a/models/template/readme.rst
+++ b/models/template/readme.rst
@@ -589,7 +589,7 @@ A note about documentation style. Optional arguments are enclosed in brackets *[
       integer,             intent(in)  :: num
       type(location_type), intent(in)  :: locs(:)
       integer,             intent(in)  :: loc_qtys(:)
-      integer,             intent(in)  :: loc_types(:)
+      integer,             intent(in)  :: loc_indx(:)
       integer,             intent(in)  :: which_vert
       integer,             intent(out) :: status(:)
 
@@ -608,7 +608,7 @@ A note about documentation style. Optional arguments are enclosed in brackets *[
    +------------------+--------------------------------------------------------------------------------------------------+
    | ``loc_qtys``     | the array of state quantities.                                                                   |
    +------------------+--------------------------------------------------------------------------------------------------+
-   | ``loc_types``    | the array of state types.                                                                        |
+   | ``loc_indx``     | the array of state indices.                                                                      |
    +------------------+--------------------------------------------------------------------------------------------------+
    | ``which_vert``   | the desired vertical coordinate system. There is a table in the ``location_mod.f90`` that        |
    |                  | relates integers to vertical coordinate systems.                                                 |

--- a/models/template/readme.rst
+++ b/models/template/readme.rst
@@ -589,7 +589,7 @@ A note about documentation style. Optional arguments are enclosed in brackets *[
       integer,             intent(in)  :: num
       type(location_type), intent(in)  :: locs(:)
       integer,             intent(in)  :: loc_qtys(:)
-      integer,             intent(in)  :: loc_indx(:)
+      integer(i8),         intent(in)  :: loc_indx(:)
       integer,             intent(in)  :: which_vert
       integer,             intent(out) :: status(:)
 

--- a/models/utilities/default_model_mod.rst
+++ b/models/utilities/default_model_mod.rst
@@ -474,14 +474,14 @@ A note about documentation style. Optional arguments are enclosed in brackets *[
 
 .. container:: routine
 
-   *call convert_vertical_state(state_handle, num, locs, loc_qtys, loc_types, which_vert, status)*
+   *call convert_vertical_state(state_handle, num, locs, loc_qtys, loc_indx, which_vert, status)*
    ::
 
       type(ensemble_type), intent(in)  :: state_handle
       integer,             intent(in)  :: num
       type(location_type), intent(in)  :: locs(:)
       integer,             intent(in)  :: loc_qtys(:)
-      integer,             intent(in)  :: loc_types(:)
+      integer,             intent(in)  :: loc_indx(:)
       integer,             intent(in)  :: which_vert
       integer,             intent(out) :: status(:)
 
@@ -498,7 +498,7 @@ A note about documentation style. Optional arguments are enclosed in brackets *[
    +------------------+--------------------------------------------------------------------------------------------------+
    | ``loc_qtys``     | the array of state quantities.                                                                   |
    +------------------+--------------------------------------------------------------------------------------------------+
-   | ``loc_types``    | the array of state types.                                                                        |
+   | ``loc_indx``     | the array of state vector indices.                                                               |
    +------------------+--------------------------------------------------------------------------------------------------+
    | ``which_vert``   | the desired vertical coordinate system. There is a table in the ``location_mod.f90`` that        |
    |                  | relates integers to vertical coordinate systems.                                                 |

--- a/models/utilities/default_model_mod.rst
+++ b/models/utilities/default_model_mod.rst
@@ -481,7 +481,7 @@ A note about documentation style. Optional arguments are enclosed in brackets *[
       integer,             intent(in)  :: num
       type(location_type), intent(in)  :: locs(:)
       integer,             intent(in)  :: loc_qtys(:)
-      integer,             intent(in)  :: loc_indx(:)
+      integer(i8),         intent(in)  :: loc_indx(:)
       integer,             intent(in)  :: which_vert
       integer,             intent(out) :: status(:)
 

--- a/models/wrf/model_mod.f90
+++ b/models/wrf/model_mod.f90
@@ -2985,7 +2985,7 @@ subroutine convert_vertical_state(state_handle, num, locs, loc_qtys, loc_indx, &
                                   which_vert, istatus)
 
 type(ensemble_type), intent(in)    :: state_handle
-integer(i8),         intent(in)    :: num
+integer,             intent(in)    :: num
 type(location_type), intent(inout) :: locs(:)
 integer,             intent(in)    :: loc_qtys(:)
 integer(i8),         intent(in)    :: loc_indx(:)

--- a/models/wrf/model_mod.f90
+++ b/models/wrf/model_mod.f90
@@ -373,7 +373,8 @@ integer :: io, iunit
 
 character (len=1)     :: idom
 logical, parameter    :: debug = .false.
-integer               :: ind, i, j, k, id, dart_index
+integer               :: ind, i, j, k, id
+integer(i8)           :: dart_index
 integer               :: my_index
 integer               :: var_element_list(max_state_variables)
 logical               :: var_update_list(max_state_variables)

--- a/models/wrf/model_mod.f90
+++ b/models/wrf/model_mod.f90
@@ -2964,7 +2964,7 @@ subroutine convert_vertical_obs(state_handle, num, locs, loc_qtys, loc_types, &
                                 which_vert, status)
 
 type(ensemble_type), intent(in)    :: state_handle
-integer,             intent(in)    :: num
+integer(i8),         intent(in)    :: num
 type(location_type), intent(inout) :: locs(:)
 integer,             intent(in)    :: loc_qtys(:)
 integer,             intent(in)    :: loc_types(:)
@@ -2985,7 +2985,7 @@ subroutine convert_vertical_state(state_handle, num, locs, loc_qtys, loc_indx, &
                                   which_vert, istatus)
 
 type(ensemble_type), intent(in)    :: state_handle
-integer,             intent(in)    :: num
+integer(i8),         intent(in)    :: num
 type(location_type), intent(inout) :: locs(:)
 integer,             intent(in)    :: loc_qtys(:)
 integer(i8),         intent(in)    :: loc_indx(:)

--- a/models/wrf/model_mod.f90
+++ b/models/wrf/model_mod.f90
@@ -3710,52 +3710,6 @@ end subroutine vert_convert
 
 !#######################################################################
 
-
-function get_wrf_index( i,j,k,var_type,id )
-
-integer, intent(in) :: i,j,k,var_type,id
-
-integer :: get_wrf_index
-integer :: in
-
-write(errstring,*)'function get_wrf_index should not be called -- still needs updating!'
-call error_handler(E_ERR,'get_wrf_index', errstring, &
-     source, revision, revdate)
-
-do in = 1, wrf%dom(id)%number_of_wrf_variables
-   if(var_type == wrf%dom(id)%var_type(in) ) then
-      exit
-   endif
-enddo
-
-! If one decides to use get_wrf_index, then the following test should be updated
-!   to take periodicity into account at the boundaries -- or should it?
-if(i >= 1 .and. i <= wrf%dom(id)%var_size(1,in) .and. &
-   j >= 1 .and. j <= wrf%dom(id)%var_size(2,in) .and. &
-   k >= 1 .and. k <= wrf%dom(id)%var_size(3,in)) then
-
-   get_wrf_index = wrf%dom(id)%dart_ind(i,j,k,var_type)
-
-!!$   get_wrf_index = wrf%dom(id)%var_index(1,in)-1 +   &
-!!$        i + wrf%dom(id)%var_size(1,in)*((j-1) + &
-!!$        wrf%dom(id)%var_size(2,in)*(k-1))
-
-else
-
-  write(errstring,*)'Indices ',i,j,k,' exceed grid dimensions: ', &
-       wrf%dom(id)%var_size(1,in), &
-       wrf%dom(id)%var_size(2,in),wrf%dom(id)%var_size(3,in)
-  call error_handler(E_ERR,'get_wrf_index', errstring, &
-       source, revision, revdate)
-
-endif
-
-end function get_wrf_index
-
-
-!***********************************************************************
-
-
 subroutine get_wrf_horizontal_location( i, j, var_type, id, long, lat )
 
 integer,  intent(in)  :: i,j,var_type, id
@@ -8472,7 +8426,6 @@ print*, 'description, units, stagger, coordinates ', size(wrf%dom(domain)%descri
                                                      size(wrf%dom(domain)%stagger), &
                                                      size(wrf%dom(domain)%coordinates)
 
-print*, 'dart_ind ', size(wrf%dom(domain)%dart_ind)
 print*
 
 end subroutine static_data_sizes

--- a/models/wrf/model_mod.f90
+++ b/models/wrf/model_mod.f90
@@ -343,13 +343,12 @@ TYPE wrf_static_data_for_dart
    character(len=10), dimension(:),pointer :: clamp_or_fail
    character(len=129),dimension(:),pointer :: description, units, stagger, coordinates
 
-   integer, dimension(:,:,:,:), pointer :: dart_ind
 
 end type wrf_static_data_for_dart
 
 type wrf_dom
    type(wrf_static_data_for_dart), pointer :: dom(:)
-   integer :: model_size
+   integer(i8) :: model_size
 end type wrf_dom
 
 type(wrf_dom) :: wrf

--- a/models/wrf/model_mod.f90
+++ b/models/wrf/model_mod.f90
@@ -2964,7 +2964,7 @@ subroutine convert_vertical_obs(state_handle, num, locs, loc_qtys, loc_types, &
                                 which_vert, status)
 
 type(ensemble_type), intent(in)    :: state_handle
-integer(i8),         intent(in)    :: num
+integer,             intent(in)    :: num
 type(location_type), intent(inout) :: locs(:)
 integer,             intent(in)    :: loc_qtys(:)
 integer,             intent(in)    :: loc_types(:)


### PR DESCRIPTION
## Description:
<!--- Describe your changes -->
Model size in DART can be an i8 number. However, some of the indexing into the state vector was not set up to use i8.
This problem was discovered by a user was running a large wrf perfect_model_obs (3796738754 elements in the state vector).

This pull request contains:

* wrf model_mod.f90 fixes to use i8  for model size. This includes removing the function `get_wrf_index` which is not used (and not i8)
* direct_netcdf_mod.f90, state_structure_mod.f90, state_vector_io_mod.f90 have i8 integers for variables that deal with indices into the state vector. 
* mpi_utitliites_mod.f90  `itemcount` is now i8 so the `else` clause of `if (itemcount <= SNDRCV_MAXSIZE)` is entered.  Bug fix 
  in the receive section for number of elements sent (was itemsize, now next size)
  There is a test added in developer_tests/mpi_utilities/tests   `ftest_sendrecv_big` to test sending large messages.
* check and bail if my_num_vars is >= i4
* comment correction in perfect_model_obs. removes outdate info about perfect_model_obs being not-mpi.

### Fixes issue
<!--- link to github issue(s) -->
fixes: #278

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
I have changed the description for convert_state_vertical which did not have loc_indx(:) (i8 index into the state vector)

### Tests
Please describe any tests you ran to verify your changes.

* perfect_model_obs with 3796738754 element wrf to test the state io.  Checked output state is the same as the input state (not advancing the model). Note I ran this on big memory nodes on Casper.
* added a ftest_sendrecv_big for large message.
* bitwise small wrf filter (intel and gfortan) 

## Checklist for merging

- [x] Updated changelog entry
- [x] Documentation updated
- [x] Version tag 

## Testing Datasets

- [x] Dataset needed for testing available upon request 
- [ ] Dataset download instructions included
- [ ] No dataset needed
