### PR TITLE
fix for perfect_model_obs memory corruption

### DIFF
--- a/assimilation_code/programs/perfect_model_obs/perfect_model_obs.f90
+++ b/assimilation_code/programs/perfect_model_obs/perfect_model_obs.f90
@@ -262,6 +262,15 @@ has_cycling = single_file_out
 call parse_filenames(input_state_files,  input_filelist,  nfilesin)
 call parse_filenames(output_state_files, output_filelist, nfilesout)
 
+!> @todo FIXME  if nfilesout == 0 and write_output_state_to_file is .false.
+!> that shouldn't be an error.  if nfilesin == 0 and read_input_state_from_file
+!> is false, that also shouldn't be an error.  (unless you're writing the mean
+!> and sd, and then maybe we should have a different name for output of input values.)
+if (nfilesin == 0 .or. nfilesout == 0 ) then
+   msgstring = 'must specify both "input_state_files" and "output_state_files" in the namelist'
+   call error_handler(E_ERR,'perfect_main',msgstring,source)
+endif
+
 allocate(true_state_filelist(nfilesout))
 
 ! mutiple domains ( this is very unlikely to be the case, but in order to
@@ -273,15 +282,6 @@ if (nfilesout > 1) then
    enddo
 else
    true_state_filelist(1) = 'true_state.nc'
-endif
-
-!> @todo FIXME  if nfilesout == 0 and write_output_state_to_file is .false.
-!> that shouldn't be an error.  if nfilesin == 0 and read_input_state_from_file
-!> is false, that also shouldn't be an error.  (unless you're writing the mean
-!> and sd, and then maybe we should have a different name for output of input values.)
-if (nfilesin == 0 .or. nfilesout == 0 ) then
-   msgstring = 'must specify both "input_state_files" and "output_state_files" in the namelist'
-   call error_handler(E_ERR,'perfect_main',msgstring,source)
 endif
 
 call io_filenames_init(file_info_input,  1, cycling=has_cycling, single_file=single_file_in)


### PR DESCRIPTION
fixes the memory corruption in #252

## Description:
<!--- Describe your changes -->
Moved the check and bail out for nfiles=0 to before the arrays with nfiles are used. 

Note I have not addressed the question of whether perfect_model_obs should continue (or not) with empty " " . This bug fix just stops the code having a memory error (this error was preventing perfect_model_obs from exiting properly on mac). 

### Fixes issue
<!--- link to github issue(s) -->
Fixes: #252

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

### Tests
Please describe any tests you ran to verify your changes.

Ran lorenz_96 perfect_model_obs with the following namelist option:

```
output_state_files         = ""
```

## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Version tag 

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [x] No dataset needed
