### PR TITLE
Removed the outlier threshold test for posterior adaptive inflation s…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,8 +24,8 @@ The changes are now listed with the most recent at the top.
 
 **November 22 2021 :: Bug fix for groups with posterior spatially-varying adaptive inflation. Tag: v9.12.13**
 
-- Removed the additional outlier threshold check for each group when using posterior 
-  spatially-varying adaptive inflation. The outlier threshold is done for the entire ensemble
+- Removed the additional outlier threshold test for each group when using posterior 
+  spatially-varying adaptive inflation. The outlier test is done for the entire ensemble
   when the posterior forward operators are computed.
 
 **October 27 2021 :: Observation converter documentation update. Tag: v9.11.12**

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,12 @@ individual files.
 
 The changes are now listed with the most recent at the top.
 
+**November 22 2021 :: Bug fix for groups with posterior spatially-varying adaptive inflation. Tag: v9.12.13**
+
+- Removed the additional outlier threshold check for each group when using posterior 
+  spatially-varying adaptive inflation. The outlier threshold is done for the entire ensemble
+  when the posterior forward operators are computed.
+
 **October 27 2021 :: Observation converter documentation update. Tag: v9.11.12**
 
 - Improved documentation for radar observation converters

--- a/assimilation_code/modules/assimilation/assim_tools_mod.f90
+++ b/assimilation_code/modules/assimilation/assim_tools_mod.f90
@@ -1133,7 +1133,10 @@ SEQUENTIAL_OBS: do i = 1, obs_ens_handle%num_vars
                diff_sd = sqrt(obs_err_var + r_var)
                if (diff_sd > 0.0_r8) then
                   outlier_ratio = abs(obs(1) - r_mean) / diff_sd
-                  do_adapt_inf_update = (outlier_ratio <= 3.0_r8)
+                  ! Outlier thresholds already enforced by posterior forward operators
+                  !do_adapt_inf_update = (outlier_ratio <= 3.0_r8)
+                  ! Always update the posterior, no matter what the group outlier_ratio
+                  do_adapt_inf_update = .true.
                endif
             endif
             if (do_adapt_inf_update) then

--- a/conf.py
+++ b/conf.py
@@ -21,7 +21,7 @@ copyright = '2021, University Corporation for Atmospheric Research'
 author = 'Data Assimilation Research Section'
 
 # The full version, including alpha/beta/rc tags
-release = '9.11.12'
+release = '9.11.13'
 master_doc = 'README'
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
…ince

the outlier threshold has already been checked when computing forward
operators. Note that the removed test could have an impact when using
groups with posterior inflation since the test was for the group subset
of the ensemble here.

## Description:
When using groups with posterior spatially-varying adaptive inflation, an outlier threshold test was done on each group during the adaptive inflation computation. This test had a hard-coded value of 3. An outlier test is already done for the entire ensemble when the posterior forward operators are computed, using the namelist outlier threshold. When the test for the whole ensemble was passed, but the additional test for the group failed, the information from the failed group was still used for subsequent groups which was clearly inconsistent with the original intent. This fix removes the additional outlier threshold check on the groups. This can change answers when using posterior inflation with more than one group. 

A single line of executable code is modified:
                  do_adapt_inf_update = (outlier_ratio <= 3.0_r8).   Old code
                  do_adapt_inf_update = .true.                                       New code



### Fixes issue
fixes #310

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

### Tests
The update was run with a suite of options with Lorenz-96 to check that made no changes to results unless run with adaptive inflation with two or more groups. Results did change when using two groups and posterior adaptive inflation, but with a namelist outlier threshold of 3, only three out of 41000 observations assimilated resulted in a change. Results were qualitatively unchanged even with posterior adaptive inflation and two groups.

## Checklist for merging

- [x] Updated changelog entry
- [ ] Documentation updated
- [x] Version tag 

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [x] No dataset needed
