### PR TITLE
bug-fix: rtps inflation 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,11 @@ individual files.
 
 The changes are now listed with the most recent at the top.
 
+**May 23 2022 :: Bug-fix for RTPS inflation flavor. Tag: v9.16.4**
+
+- Order of operations changed to avoid inadvertent changes to ens 
+  when using RTPS.
+
 **May 16 2022 :: Installation documentation update. Tag: v9.16.3**
 
 - Improved installation documentation.

--- a/assimilation_code/modules/assimilation/adaptive_inflate_mod.f90
+++ b/assimilation_code/modules/assimilation/adaptive_inflate_mod.f90
@@ -550,7 +550,7 @@ if(inflate_handle%deterministic) then
       ! only inflate if spreads are > 0
       if ( asprd .gt. 0.0_r8 .and. fsprd .gt. 0.0_r8) &
           inflate = 1.0_r8 + inflate * ((fsprd-asprd) / asprd) 
-          ens     = mean + (ens-mean) * inflate 
+          ens = ens * inflate + mean * (1.d0 - inflate)
    else 
 
       ! Spread the ensemble out linearly for deterministic

--- a/assimilation_code/modules/assimilation/adaptive_inflate_mod.f90
+++ b/assimilation_code/modules/assimilation/adaptive_inflate_mod.f90
@@ -550,7 +550,7 @@ if(inflate_handle%deterministic) then
       ! only inflate if spreads are > 0
       if ( asprd .gt. 0.0_r8 .and. fsprd .gt. 0.0_r8) &
           inflate = 1.0_r8 + inflate * ((fsprd-asprd) / asprd) 
-          ens = ens * inflate + mean * (1.d0 - inflate)
+          ens = ens * inflate + mean * (1.0_r8 - inflate)
    else 
 
       ! Spread the ensemble out linearly for deterministic

--- a/conf.py
+++ b/conf.py
@@ -21,7 +21,7 @@ copyright = '2021, University Corporation for Atmospheric Research'
 author = 'Data Assimilation Research Section'
 
 # The full version, including alpha/beta/rc tags
-release = '9.16.3'
+release = '9.16.4'
 master_doc = 'README'
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
Bug fix for rpts with inflate=1
Follows the non-rtps order of operations to avoid inflation of 1.0 changing ens.

## Description:
<!--- Describe your changes -->
Please provide a summary of the change and include any relevant motivation and context. 

### Fixes issue
Fixes #353 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

### Tests



```
$cat test_order.f90 
program order

implicit none

integer,parameter :: n = 3
real*8 :: ens(n), mean, inflate
real*8 :: ens2(n), ens3(n), ens4(n)
integer :: i

inflate = 1.d0

do i = 1, n
   ens(i) = real(i,8)/10000
   mean = mean + ens(i)
enddo
!mean = mean/real(n,8)
! This is not the mean, just a number to trigger differences in the 
! calculation for this test code
mean = 4.0d8


ens2 = mean + (ens-mean) * inflate 
ens3 = ens * inflate + mean * (1.d0 - inflate)
ens4 = ens*inflate + mean - mean*inflate

print*, 'mean', mean
print*, 'ens ', ens
print*, 'ens2 ', ens2
print*, 'ens3 ', ens3
print*, 'ens4 ', ens4

end program order
```

```
gfortran test_order.f90 
./a.out

mean   400000000.00000000     
 ens    1.0000000000000000E-004   2.0000000000000001E-004   2.9999999999999997E-004
 ens2    1.0001659393310547E-004   1.9997358322143555E-004   2.9999017715454102E-004
 ens3    1.0000000000000000E-004   2.0000000000000001E-004   2.9999999999999997E-004
 ens4    1.0001659393310547E-004   1.9997358322143555E-004   2.9999017715454102E-004
```

```
ifort test_order.f90 
./a.out 
mean   400000000.000000     
 ens   1.000000000000000E-004  2.000000000000000E-004  3.000000000000000E-004
 ens2   1.000165939331055E-004  1.999735832214355E-004  3.000000000000000E-004
 ens3   1.000000000000000E-004  2.000000000000000E-004  3.000000000000000E-004
 ens4   1.000165939331055E-004  1.999735832214355E-004  3.000000000000000E-004
```

## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Version tag 

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [ ] No dataset needed
