### PR TITLE
var obs converter quickbuild.sh fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,6 +153,9 @@ convert_gpsro_bufr
 SMAP_L2_to_obs
 convert_sat_chl
 ssec_satwnd
+gts_to_dart
+littler_tf_dart
+rad_3dvar_to_dart
 
 # Test programs built by developer_tests
 rttov_test

--- a/observations/obs_converters/var/3DVAR_OBSPROC/README
+++ b/observations/obs_converters/var/3DVAR_OBSPROC/README
@@ -9,7 +9,7 @@ will need to copy some of the WRF distribution files into
 this directory.  The files listed below are what is needed 
 with WRFDA v3.2.1 (the current release at this time).
 
-From WRFDA/var/obsproc/MAP_plot/Dir_map, copy to here:
+From WRF/var/obsproc/MAP_plot/Dir_map, copy to here:
 
 DA_Constants.f90
 DA_Define_Structures.f90
@@ -26,7 +26,7 @@ nestdmn.incl
 
 See here for more info on this code:
 
-http://www.mmm.ucar.edu/wrf/WG4/wrfvar/3dvar_obsproc.htm
+https://github.com/wrf-model/WRF/releases
 
 # <next few lines under version control, do not edit>
 # $URL$

--- a/observations/obs_converters/var/var.rst
+++ b/observations/obs_converters/var/var.rst
@@ -17,7 +17,8 @@ obs formats related to 3D-Var, WRF-Var, and MM5:
 
 You need to add some WRF-Var source files to the 3DVAR_OBSPROC
 directory, and then you can go into the work directory and
-run the 'quickbuild.sh' script.
+run the 'quickbuild.sh' script. The required WRF-Var source files are
+listed in ``3DVAR_OBSPROC/README``.
 
 The little-r converter may need changes to the code to convert
 from the original quality control flags into QC flags compatible

--- a/observations/obs_converters/var/work/quickbuild.sh
+++ b/observations/obs_converters/var/work/quickbuild.sh
@@ -12,7 +12,8 @@ source "$DART"/build_templates/buildconvfunctions.sh
 CONVERTER=var
 LOCATION=threed_sphere
 EXTRA="$DART/models/wrf/model_mod.f90 \
-       $DART/models/wrf/module_map_utils.f90"
+       $DART/models/wrf/module_map_utils.f90 \
+       $DART/observations/obs_converters/var/3DVAR_OBSPROC"
 
 
 programs=(


### PR DESCRIPTION
## Description:
<!--- Describe your changes -->
var observation converter was not being built by quickbuild.sh
Added the 3DVAR_OBSPROC directory to quickbuild.sh so the build completes successfully.

### Fixes issue
<!--- link to github issue(s) -->
Fixes #361

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly:
Fixed broken WRFDA link in README and added where to find the list of WRF files to var.rst 

### Tests

Compiled converter:
 - The converter requires code from https://github.com/wrf-model/WRF.git or https://github.com/wrf-model/WRFDA.git
   Tested the build with both of these. 

## Checklist for merging

- [ ] Updated changelog entry
- [x] Documentation updated
- [ ] Version tag 

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [x] No dataset needed
