### PR TITLE
Fix for  MITgcm_ocean pert_model_copies

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,16 @@ individual files.
 
 The changes are now listed with the most recent at the top.
 
+**June 24 2022 :: Bug-fixes for MITgcm_ocean and Var obs converter. Tag: v10.0.2**
+
+- MITgcm_ocean pert_model_copies routine fixed to use the correct variable clamping
+  value and indices for each element of the copies array. 
+- Var obs converter quicklbuild.sh fixed to correctly locate the required 
+  3DVAR_OBSPROC code.
+- Documentation for Var obs converter updated with information for where to 
+  get the latest WRF 3DVAR_OBSPROC code.
+
+
 **June 2 2022 :: Bug-fixes for ps_rand_local in the Bgrid Model. Tag: v10.0.1**
 
 - performs the missing call for initialize_utilities() 

--- a/conf.py
+++ b/conf.py
@@ -21,7 +21,7 @@ copyright = '2021, University Corporation for Atmospheric Research'
 author = 'Data Assimilation Research Section'
 
 # The full version, including alpha/beta/rc tags
-release = '10.0.1'
+release = '10.0.2'
 master_doc = 'README'
 
 # -- General configuration ---------------------------------------------------

--- a/models/MITgcm_ocean/model_mod.f90
+++ b/models/MITgcm_ocean/model_mod.f90
@@ -1323,7 +1323,7 @@ VARIABLES : do ivar = 1, get_num_variables(domain_id)
 
    clamp_min_val = get_io_clamping_minval(domain_id, ivar)
 
-   INDICES : do i = start_ind, end_ind
+   INDICES : do i = 1, state_ens_handle%my_num_vars
       MEMBERS : do copy = 1, ens_size
 
          ! Only perturb the actual ocean cells;

--- a/models/MITgcm_ocean/model_mod.f90
+++ b/models/MITgcm_ocean/model_mod.f90
@@ -1361,12 +1361,12 @@ if ( .not. module_initialized ) call static_init_model
 
 read_model_time = model_time
 
-!if (do_output() .and. debug > 0 .and. present(last_time)) then
+if (do_output()) then
    call print_time(read_model_time, str='MITgcm_ocean time is ',iunit=logfileunit)
    call print_time(read_model_time, str='MITgcm_ocean time is ')
    call print_date(read_model_time, str='MITgcm_ocean date is ',iunit=logfileunit)
    call print_date(read_model_time, str='MITgcm_ocean date is ')
-!endif
+endif
 
 end function read_model_time
 

--- a/models/MITgcm_ocean/model_mod.f90
+++ b/models/MITgcm_ocean/model_mod.f90
@@ -1331,9 +1331,7 @@ INDICES : do i = 1, state_ens_handle%my_num_vars
                                       model_perturbation_amplitude)
 
       ! Clamping: Samples obtained from truncated Gaussian dist. 
-      if (.not. log_transform) then
-         pertval = max(clamp_min_val, pertval)
-      endif
+      if (.not. log_transform) pertval = max(clamp_min_val, pertval)
 
       state_ens_handle%copies(copy, i) = pertval
 

--- a/models/MITgcm_ocean/model_mod.f90
+++ b/models/MITgcm_ocean/model_mod.f90
@@ -97,8 +97,6 @@ character(len=*), parameter :: source = 'MITgcm_ocean/model_mod.f90'
 character(len=512) :: string1, string2, string3
 logical, save      :: module_initialized = .false.
 
-! Storage for a random sequence for perturbing a single initial state
-type(random_seq_type) :: random_seq
 
 !------------------------------------------------------------------
 !
@@ -1304,9 +1302,11 @@ integer,             intent(in)    :: ens_size
 real(r8),            intent(in)    :: pert_amp
 logical,             intent(out)   :: interf_provided
 
-integer  :: i, ivar
-integer  :: copy, start_ind, end_ind
+integer  :: ivar
+integer  :: copy
+integer  :: i
 real(r8) :: pertval, clamp_min_val 
+integer  :: iloc, jloc, kloc ! not used, but required for get_model_variable_indices
 
 type(random_seq_type) :: random_seq
 
@@ -1315,33 +1315,30 @@ if ( .not. module_initialized ) call static_init_model
 interf_provided = .true.
 
 call init_random_seq(random_seq, my_task_id())
+ 
+INDICES : do i = 1, state_ens_handle%my_num_vars
 
-VARIABLES : do ivar = 1, get_num_variables(domain_id)
-
-   start_ind = get_index_start(domain_id, ivar)
-   end_ind   = get_index_end(  domain_id, ivar)
-
+   call get_model_variable_indices(state_ens_handle%my_vars(i), iloc, jloc, kloc, ivar)
    clamp_min_val = get_io_clamping_minval(domain_id, ivar)
 
-   INDICES : do i = 1, state_ens_handle%my_num_vars
-      MEMBERS : do copy = 1, ens_size
+   MEMBERS : do copy = 1, ens_size
 
-         ! Only perturb the actual ocean cells;
-         ! Leave the land and ocean floor values alone.
-         if( state_ens_handle%copies(copy, i) == FVAL ) cycle MEMBERS
+      ! Only perturb the actual ocean cells;
+      ! Leave the land and ocean floor values alone.
+      if( state_ens_handle%copies(copy, i) == FVAL ) cycle MEMBERS
 
-         pertval = random_gaussian(random_seq, state_ens_handle%copies(copy, i), &
-                                         model_perturbation_amplitude)
+      pertval = random_gaussian(random_seq, state_ens_handle%copies(copy, i), &
+                                      model_perturbation_amplitude)
 
-         ! Clamping: Samples obtained from truncated Gaussian dist. 
-         if (.not. log_transform) pertval = max(clamp_min_val, pertval)
+      ! Clamping: Samples obtained from truncated Gaussian dist. 
+      if (.not. log_transform) then
+         pertval = max(clamp_min_val, pertval)
+      endif
 
-         state_ens_handle%copies(copy, i) = pertval
+      state_ens_handle%copies(copy, i) = pertval
 
-      enddo MEMBERS
-   enddo INDICES
-
-enddo VARIABLES
+   enddo MEMBERS
+enddo INDICES
 
 end subroutine pert_model_copies
 


### PR DESCRIPTION
## Description:
<!--- Describe your changes -->
* Querying the variable id and clamping value for each state element.  
In pert_model_copies the state vector is spread out round-robin across the processors, so the check for clamping value must be done for each element.  
* INDICES loop is now `INDICES : do i = 1, state_ens_handle%my_num_vars`.  Previously the INDICES loop was 
  `INDICES : do i = start_ind, end_ind` which caused pert_model_copies to segfault.

* Removed module global random_seq since this is not used.

### Fixes issue
<!--- link to github issue(s) -->
fixes #360 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

### Tests
Perturbed MIT ocean test case.

## Checklist for merging

- [x] Updated changelog entry
- [ ] Documentation updated
- [x] Version tag 

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [x] Dataset download instructions included
- [ ] No dataset needed

Here is a test case for filter log_transform=.false.
/glade/scratch/hkershaw/DART/MITgcm/test_small_domain.no-nans.no-log

And for log_transform=.true.
/glade/scratch/hkershaw/DART/MITgcm/test_small_domain.no-nans.log


