### PR TITLE
Redundant caching in assim_tools_mod.f90

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,10 @@ individual files.
 
 The changes are now listed with the most recent at the top.
 
+**July 14 2022 :: Performance improvement - removal of redundant caching. Tag: v10.0.3**
+- Reduces the runtime by removing redundant caching in the get_close_obs_cached and 
+  get_close_state_cached subroutines in assim_tools_mod.f90
+
 **June 24 2022 :: Bug-fixes for MITgcm_ocean and Var obs converter. Tag: v10.0.2**
 
 - MITgcm_ocean pert_model_copies routine fixed to use the correct variable clamping

--- a/assimilation_code/modules/assimilation/assim_tools_mod.f90
+++ b/assimilation_code/modules/assimilation/assim_tools_mod.f90
@@ -332,8 +332,6 @@ real(r8) :: obs_prior_mean(num_groups), obs_prior_var(num_groups)
 real(r8) :: vertvalue_obs_in_localization_coord, whichvert_real
 real(r8), allocatable :: close_obs_dist(:)
 real(r8), allocatable :: close_state_dist(:)
-real(r8), allocatable :: last_close_obs_dist(:)
-real(r8), allocatable :: last_close_state_dist(:)
 
 integer(i8) :: state_index
 integer(i8), allocatable :: my_state_indx(:)
@@ -351,8 +349,6 @@ integer :: whichvert_obs_in_localization_coord
 integer :: istatus, localization_unit
 integer, allocatable :: close_obs_ind(:)
 integer, allocatable :: close_state_ind(:)
-integer, allocatable :: last_close_obs_ind(:)
-integer, allocatable :: last_close_state_ind(:)
 integer, allocatable :: my_obs_kind(:)
 integer, allocatable :: my_obs_type(:)
 integer, allocatable :: my_state_kind(:)
@@ -376,9 +372,7 @@ logical :: local_obs_inflate
 
 ! allocate rather than dump all this on the stack
 allocate(close_obs_dist(     obs_ens_handle%my_num_vars), &
-         last_close_obs_dist(obs_ens_handle%my_num_vars), &
          close_obs_ind(      obs_ens_handle%my_num_vars), &
-         last_close_obs_ind( obs_ens_handle%my_num_vars), &
          vstatus(            obs_ens_handle%my_num_vars), &
          my_obs_indx(        obs_ens_handle%my_num_vars), &
          my_obs_kind(        obs_ens_handle%my_num_vars), &
@@ -386,9 +380,7 @@ allocate(close_obs_dist(     obs_ens_handle%my_num_vars), &
          my_obs_loc(         obs_ens_handle%my_num_vars))
 
 allocate(close_state_dist(     ens_handle%my_num_vars), &
-         last_close_state_dist(ens_handle%my_num_vars), &
          close_state_ind(      ens_handle%my_num_vars), &
-         last_close_state_ind( ens_handle%my_num_vars), &
          my_state_indx(        ens_handle%my_num_vars), &
          my_state_kind(        ens_handle%my_num_vars), &
          my_state_loc(         ens_handle%my_num_vars))
@@ -544,10 +536,6 @@ if (close_obs_caching) then
    last_base_states_loc        = set_location_missing()
    last_num_close_obs          = -1
    last_num_close_states       = -1
-   last_close_obs_ind(:)       = -1
-   last_close_state_ind(:)     = -1
-   last_close_obs_dist(:)      = 888888.0_r8   ! something big, not small
-   last_close_state_dist(:)    = 888888.0_r8   ! ditto
    num_close_obs_cached        = 0
    num_close_states_cached     = 0
    num_close_obs_calls_made    = 0
@@ -676,8 +664,8 @@ SEQUENTIAL_OBS: do i = 1, obs_ens_handle%num_vars
    ! Do get_close_obs first, even though state space increments are computed before obs increments.
    call  get_close_obs_cached(gc_obs, base_obs_loc, base_obs_type,      &
       my_obs_loc, my_obs_kind, my_obs_type, num_close_obs, close_obs_ind, close_obs_dist,  &
-      ens_handle, last_base_obs_loc, last_num_close_obs, last_close_obs_ind,               &
-      last_close_obs_dist, num_close_obs_cached, num_close_obs_calls_made)
+      ens_handle, last_base_obs_loc, last_num_close_obs, num_close_obs_cached,             &
+      num_close_obs_calls_made)
 
    ! set the cutoff default, keep a copy of the original value, and avoid
    ! looking up the cutoff in a list if the incoming obs is an identity ob
@@ -697,8 +685,8 @@ SEQUENTIAL_OBS: do i = 1, obs_ens_handle%num_vars
    ! Find state variables on my process that are close to observation being assimilated
    call  get_close_state_cached(gc_state, base_obs_loc, base_obs_type,      &
       my_state_loc, my_state_kind, my_state_indx, num_close_states, close_state_ind, close_state_dist,  &
-      ens_handle, last_base_states_loc, last_num_close_states, last_close_state_ind,               &
-      last_close_state_dist, num_close_states_cached, num_close_states_calls_made)
+      ens_handle, last_base_states_loc, last_num_close_states, num_close_states_cached,                 &
+      num_close_states_calls_made)
    !call test_close_obs_dist(close_state_dist, num_close_states, i)
 
    ! Loop through to update each of my state variables that is potentially close
@@ -811,20 +799,16 @@ call free_mean_window()
 
 ! deallocate space
 deallocate(close_obs_dist,      &
-           last_close_obs_dist, &
            my_obs_indx,         &
            my_obs_kind,         &
            my_obs_type,         &
            close_obs_ind,       &
-           last_close_obs_ind,  &
            vstatus,             &
            my_obs_loc)
 
 deallocate(close_state_dist,      &
-           last_close_state_dist, &
            my_state_indx,         &
            close_state_ind,       &
-           last_close_state_ind,  &
            my_state_kind,         &
            my_state_loc)
 
@@ -2575,8 +2559,8 @@ end subroutine get_my_obs_loc
 
 subroutine get_close_obs_cached(gc_obs, base_obs_loc, base_obs_type, &
    my_obs_loc, my_obs_kind, my_obs_type, num_close_obs, close_obs_ind, close_obs_dist,  &
-   ens_handle, last_base_obs_loc, last_num_close_obs, last_close_obs_ind,               &
-   last_close_obs_dist, num_close_obs_cached, num_close_obs_calls_made)
+   ens_handle, last_base_obs_loc, last_num_close_obs, num_close_obs_cached,              &
+   num_close_obs_calls_made)
 
 type(get_close_type),          intent(in)  :: gc_obs
 type(location_type),           intent(inout) :: base_obs_loc, my_obs_loc(:)
@@ -2587,8 +2571,6 @@ real(r8),                      intent(inout) :: close_obs_dist(:)
 type(ensemble_type),           intent(in)  :: ens_handle
 type(location_type), intent(inout) :: last_base_obs_loc
 integer, intent(inout) :: last_num_close_obs
-integer, intent(inout) :: last_close_obs_ind(:)
-real(r8), intent(inout) :: last_close_obs_dist(:)
 integer, intent(inout) :: num_close_obs_cached, num_close_obs_calls_made
 
 ! This logic could be arranged to make code less redundant
@@ -2623,8 +2605,8 @@ end subroutine get_close_obs_cached
 
 subroutine get_close_state_cached(gc_state, base_obs_loc, base_obs_type, &
    my_state_loc, my_state_kind, my_state_indx, num_close_states, close_state_ind, close_state_dist,  &
-   ens_handle, last_base_states_loc, last_num_close_states, last_close_state_ind,               &
-   last_close_state_dist, num_close_states_cached, num_close_states_calls_made)
+   ens_handle, last_base_states_loc, last_num_close_states, num_close_states_cached,              &
+   num_close_states_calls_made)
 
 type(get_close_type),          intent(in)    :: gc_state
 type(location_type),           intent(inout) :: base_obs_loc, my_state_loc(:)
@@ -2636,8 +2618,6 @@ real(r8),                      intent(inout)   :: close_state_dist(:)
 type(ensemble_type),           intent(in)    :: ens_handle
 type(location_type), intent(inout) :: last_base_states_loc
 integer, intent(inout) :: last_num_close_states
-integer, intent(inout) :: last_close_state_ind(:)
-real(r8), intent(inout) :: last_close_state_dist(:)
 integer, intent(inout) :: num_close_states_cached, num_close_states_calls_made
 
 ! This logic could be arranged to make code less redundant

--- a/assimilation_code/modules/assimilation/assim_tools_mod.f90
+++ b/assimilation_code/modules/assimilation/assim_tools_mod.f90
@@ -2598,9 +2598,9 @@ if (.not. close_obs_caching) then
                       num_close_obs, close_obs_ind, close_obs_dist, ens_handle)
 else
    if (base_obs_loc == last_base_obs_loc) then
-      num_close_obs     = last_num_close_obs
-      close_obs_ind(:)  = last_close_obs_ind(:)
-      close_obs_dist(:) = last_close_obs_dist(:)
+  !    num_close_obs     = last_num_close_obs
+  !    close_obs_ind(:)  = last_close_obs_ind(:)
+  !    close_obs_dist(:) = last_close_obs_dist(:)
       num_close_obs_cached = num_close_obs_cached + 1
    else
       call get_close_obs(gc_obs, base_obs_loc, base_obs_type, &
@@ -2609,8 +2609,8 @@ else
 
       last_base_obs_loc      = base_obs_loc
       last_num_close_obs     = num_close_obs
-      last_close_obs_ind(:)  = close_obs_ind(:)
-      last_close_obs_dist(:) = close_obs_dist(:)
+  !    last_close_obs_ind(:)  = close_obs_ind(:)
+  !    last_close_obs_dist(:) = close_obs_dist(:)
       num_close_obs_calls_made = num_close_obs_calls_made +1
    endif
 endif

--- a/assimilation_code/modules/assimilation/assim_tools_mod.f90
+++ b/assimilation_code/modules/assimilation/assim_tools_mod.f90
@@ -2647,9 +2647,9 @@ if (.not. close_obs_caching) then
                       num_close_states, close_state_ind, close_state_dist, ens_handle)
 else
    if (base_obs_loc == last_base_states_loc) then
-      num_close_states     = last_num_close_states
-      close_state_ind(:)  = last_close_state_ind(:)
-      close_state_dist(:) = last_close_state_dist(:)
+  !    num_close_states     = last_num_close_states
+  !    close_state_ind(:)  = last_close_state_ind(:)
+  !    close_state_dist(:) = last_close_state_dist(:)
       num_close_states_cached = num_close_states_cached + 1
    else
       call get_close_state(gc_state, base_obs_loc, base_obs_type, &
@@ -2658,8 +2658,8 @@ else
 
       last_base_states_loc      = base_obs_loc
       last_num_close_states     = num_close_states
-      last_close_state_ind(:)  = close_state_ind(:)
-      last_close_state_dist(:) = close_state_dist(:)
+    !  last_close_state_ind(:)  = close_state_ind(:)
+    !  last_close_state_dist(:) = close_state_dist(:)
       num_close_states_calls_made = num_close_states_calls_made +1
    endif
 endif

--- a/assimilation_code/modules/assimilation/assim_tools_mod.f90
+++ b/assimilation_code/modules/assimilation/assim_tools_mod.f90
@@ -16,7 +16,7 @@ use  utilities_mod,       only : file_exist, get_unit, check_namelist_read, do_o
                                  find_namelist_in_file, error_handler,   &
                                  E_ERR, E_MSG, nmlfileunit, do_nml_file, do_nml_term,     &
                                  open_file, close_file, timestamp
-use       sort_mod,       only : index_sort 
+use       sort_mod,       only : index_sort
 use random_seq_mod,       only : random_seq_type, random_gaussian, init_random_seq,       &
                                  random_uniform
 
@@ -491,7 +491,7 @@ if (convert_all_obs_verticals_first .and. is_doing_vertical_conversion) then
             if (vstatus(i) /= 0) obs_ens_handle%copies(OBS_GLOBAL_QC_COPY, i) = DARTQC_FAILED_VERT_CONVERT
          endif
       enddo
-   endif 
+   endif
 endif
 
 ! Get info on my number and indices for state
@@ -632,7 +632,7 @@ SEQUENTIAL_OBS: do i = 1, obs_ens_handle%num_vars
    !-----------------------------------------------------------------------
    else
       call broadcast_recv(map_pe_to_task(ens_handle, owner), obs_prior,    &
-         orig_obs_prior_mean, orig_obs_prior_var,                          & 
+         orig_obs_prior_mean, orig_obs_prior_var,                          &
          scalar1=obs_qc, scalar2=vertvalue_obs_in_localization_coord,      &
          scalar3=whichvert_real, scalar4=my_inflate, scalar5=my_inflate_sd)
       whichvert_obs_in_localization_coord = nint(whichvert_real)
@@ -671,7 +671,7 @@ SEQUENTIAL_OBS: do i = 1, obs_ens_handle%num_vars
             orig_obs_prior_var(group), obs(1), obs_err_var, grp_size, inflate_only)
       end do
    endif
-  
+
    ! Adaptive localization needs number of other observations within localization radius.
    ! Do get_close_obs first, even though state space increments are computed before obs increments.
    call  get_close_obs_cached(gc_obs, base_obs_loc, base_obs_type,      &
@@ -715,7 +715,7 @@ SEQUENTIAL_OBS: do i = 1, obs_ens_handle%num_vars
          my_state_kind(state_index), close_state_dist(j), cutoff_rev)
 
       if(final_factor <= 0.0_r8) cycle STATE_UPDATE
-      
+
       call obs_updates_ens(ens_size, num_groups, ens_handle%copies(1:ens_size, state_index), &
          my_state_loc(state_index), my_state_kind(state_index), obs_prior, obs_inc, &
          obs_prior_mean, obs_prior_var, base_obs_loc, base_obs_type, obs_time, &
@@ -2581,8 +2581,9 @@ subroutine get_close_obs_cached(gc_obs, base_obs_loc, base_obs_type, &
 type(get_close_type),          intent(in)  :: gc_obs
 type(location_type),           intent(inout) :: base_obs_loc, my_obs_loc(:)
 integer,                       intent(in)  :: base_obs_type, my_obs_kind(:), my_obs_type(:)
-integer,                       intent(out) :: num_close_obs, close_obs_ind(:)
-real(r8),                      intent(out) :: close_obs_dist(:)
+integer,                       intent(out) :: num_close_obs
+integer,                       intent(inout) :: close_obs_ind(:)
+real(r8),                      intent(inout) :: close_obs_dist(:)
 type(ensemble_type),           intent(in)  :: ens_handle
 type(location_type), intent(inout) :: last_base_obs_loc
 integer, intent(inout) :: last_num_close_obs
@@ -2629,8 +2630,9 @@ type(get_close_type),          intent(in)    :: gc_state
 type(location_type),           intent(inout) :: base_obs_loc, my_state_loc(:)
 integer,                       intent(in)    :: base_obs_type, my_state_kind(:)
 integer(i8),                   intent(in)    :: my_state_indx(:)
-integer,                       intent(out)   :: num_close_states, close_state_ind(:)
-real(r8),                      intent(out)   :: close_state_dist(:)
+integer,                       intent(out)   :: num_close_states
+integer,                       intent(inout)   :: close_state_ind(:)
+real(r8),                      intent(inout)   :: close_state_dist(:)
 type(ensemble_type),           intent(in)    :: ens_handle
 type(location_type), intent(inout) :: last_base_states_loc
 integer, intent(inout) :: last_num_close_states
@@ -2872,4 +2874,3 @@ end subroutine test_close_obs_dist
 !========================================================================
 
 end module assim_tools_mod
-

--- a/assimilation_code/modules/assimilation/assim_tools_mod.f90
+++ b/assimilation_code/modules/assimilation/assim_tools_mod.f90
@@ -16,7 +16,7 @@ use  utilities_mod,       only : file_exist, get_unit, check_namelist_read, do_o
                                  find_namelist_in_file, error_handler,   &
                                  E_ERR, E_MSG, nmlfileunit, do_nml_file, do_nml_term,     &
                                  open_file, close_file, timestamp
-use       sort_mod,       only : index_sort
+use       sort_mod,       only : index_sort 
 use random_seq_mod,       only : random_seq_type, random_gaussian, init_random_seq,       &
                                  random_uniform
 
@@ -483,7 +483,7 @@ if (convert_all_obs_verticals_first .and. is_doing_vertical_conversion) then
             if (vstatus(i) /= 0) obs_ens_handle%copies(OBS_GLOBAL_QC_COPY, i) = DARTQC_FAILED_VERT_CONVERT
          endif
       enddo
-   endif
+   endif 
 endif
 
 ! Get info on my number and indices for state
@@ -620,7 +620,7 @@ SEQUENTIAL_OBS: do i = 1, obs_ens_handle%num_vars
    !-----------------------------------------------------------------------
    else
       call broadcast_recv(map_pe_to_task(ens_handle, owner), obs_prior,    &
-         orig_obs_prior_mean, orig_obs_prior_var,                          &
+         orig_obs_prior_mean, orig_obs_prior_var,                          & 
          scalar1=obs_qc, scalar2=vertvalue_obs_in_localization_coord,      &
          scalar3=whichvert_real, scalar4=my_inflate, scalar5=my_inflate_sd)
       whichvert_obs_in_localization_coord = nint(whichvert_real)
@@ -659,7 +659,7 @@ SEQUENTIAL_OBS: do i = 1, obs_ens_handle%num_vars
             orig_obs_prior_var(group), obs(1), obs_err_var, grp_size, inflate_only)
       end do
    endif
-
+  
    ! Adaptive localization needs number of other observations within localization radius.
    ! Do get_close_obs first, even though state space increments are computed before obs increments.
    call  get_close_obs_cached(gc_obs, base_obs_loc, base_obs_type,      &
@@ -685,7 +685,7 @@ SEQUENTIAL_OBS: do i = 1, obs_ens_handle%num_vars
    ! Find state variables on my process that are close to observation being assimilated
    call  get_close_state_cached(gc_state, base_obs_loc, base_obs_type,      &
       my_state_loc, my_state_kind, my_state_indx, num_close_states, close_state_ind, close_state_dist,  &
-      ens_handle, last_base_states_loc, last_num_close_states, num_close_states_cached,                 &
+      ens_handle, last_base_states_loc, last_num_close_states, num_close_states_cached,              &
       num_close_states_calls_made)
    !call test_close_obs_dist(close_state_dist, num_close_states, i)
 
@@ -703,7 +703,7 @@ SEQUENTIAL_OBS: do i = 1, obs_ens_handle%num_vars
          my_state_kind(state_index), close_state_dist(j), cutoff_rev)
 
       if(final_factor <= 0.0_r8) cycle STATE_UPDATE
-
+      
       call obs_updates_ens(ens_size, num_groups, ens_handle%copies(1:ens_size, state_index), &
          my_state_loc(state_index), my_state_kind(state_index), obs_prior, obs_inc, &
          obs_prior_mean, obs_prior_var, base_obs_loc, base_obs_type, obs_time, &
@@ -2559,15 +2559,14 @@ end subroutine get_my_obs_loc
 
 subroutine get_close_obs_cached(gc_obs, base_obs_loc, base_obs_type, &
    my_obs_loc, my_obs_kind, my_obs_type, num_close_obs, close_obs_ind, close_obs_dist,  &
-   ens_handle, last_base_obs_loc, last_num_close_obs, num_close_obs_cached,              &
+   ens_handle, last_base_obs_loc, last_num_close_obs, num_close_obs_cached,               &
    num_close_obs_calls_made)
 
 type(get_close_type),          intent(in)  :: gc_obs
 type(location_type),           intent(inout) :: base_obs_loc, my_obs_loc(:)
 integer,                       intent(in)  :: base_obs_type, my_obs_kind(:), my_obs_type(:)
-integer,                       intent(out) :: num_close_obs
-integer,                       intent(inout) :: close_obs_ind(:)
-real(r8),                      intent(inout) :: close_obs_dist(:)
+integer,                       intent(out) :: num_close_obs, close_obs_ind(:)
+real(r8),                      intent(out) :: close_obs_dist(:)
 type(ensemble_type),           intent(in)  :: ens_handle
 type(location_type), intent(inout) :: last_base_obs_loc
 integer, intent(inout) :: last_num_close_obs
@@ -2580,6 +2579,7 @@ if (.not. close_obs_caching) then
                       num_close_obs, close_obs_ind, close_obs_dist, ens_handle)
 else
    if (base_obs_loc == last_base_obs_loc) then
+      num_close_obs     = last_num_close_obs
       num_close_obs_cached = num_close_obs_cached + 1
    else
       call get_close_obs(gc_obs, base_obs_loc, base_obs_type, &
@@ -2600,16 +2600,15 @@ end subroutine get_close_obs_cached
 
 subroutine get_close_state_cached(gc_state, base_obs_loc, base_obs_type, &
    my_state_loc, my_state_kind, my_state_indx, num_close_states, close_state_ind, close_state_dist,  &
-   ens_handle, last_base_states_loc, last_num_close_states, num_close_states_cached,              &
+   ens_handle, last_base_states_loc, last_num_close_states, num_close_states_cached,               &
    num_close_states_calls_made)
 
 type(get_close_type),          intent(in)    :: gc_state
 type(location_type),           intent(inout) :: base_obs_loc, my_state_loc(:)
 integer,                       intent(in)    :: base_obs_type, my_state_kind(:)
 integer(i8),                   intent(in)    :: my_state_indx(:)
-integer,                       intent(out)   :: num_close_states
-integer,                       intent(inout)   :: close_state_ind(:)
-real(r8),                      intent(inout)   :: close_state_dist(:)
+integer,                       intent(out)   :: num_close_states, close_state_ind(:)
+real(r8),                      intent(out)   :: close_state_dist(:)
 type(ensemble_type),           intent(in)    :: ens_handle
 type(location_type), intent(inout) :: last_base_states_loc
 integer, intent(inout) :: last_num_close_states
@@ -2622,6 +2621,7 @@ if (.not. close_obs_caching) then
                       num_close_states, close_state_ind, close_state_dist, ens_handle)
 else
    if (base_obs_loc == last_base_states_loc) then
+      num_close_states     = last_num_close_states
       num_close_states_cached = num_close_states_cached + 1
    else
       call get_close_state(gc_state, base_obs_loc, base_obs_type, &
@@ -2844,3 +2844,4 @@ end subroutine test_close_obs_dist
 !========================================================================
 
 end module assim_tools_mod
+

--- a/assimilation_code/modules/assimilation/assim_tools_mod.f90
+++ b/assimilation_code/modules/assimilation/assim_tools_mod.f90
@@ -2580,9 +2580,6 @@ if (.not. close_obs_caching) then
                       num_close_obs, close_obs_ind, close_obs_dist, ens_handle)
 else
    if (base_obs_loc == last_base_obs_loc) then
-  !    num_close_obs     = last_num_close_obs
-  !    close_obs_ind(:)  = last_close_obs_ind(:)
-  !    close_obs_dist(:) = last_close_obs_dist(:)
       num_close_obs_cached = num_close_obs_cached + 1
    else
       call get_close_obs(gc_obs, base_obs_loc, base_obs_type, &
@@ -2591,8 +2588,6 @@ else
 
       last_base_obs_loc      = base_obs_loc
       last_num_close_obs     = num_close_obs
-  !    last_close_obs_ind(:)  = close_obs_ind(:)
-  !    last_close_obs_dist(:) = close_obs_dist(:)
       num_close_obs_calls_made = num_close_obs_calls_made +1
    endif
 endif
@@ -2627,9 +2622,6 @@ if (.not. close_obs_caching) then
                       num_close_states, close_state_ind, close_state_dist, ens_handle)
 else
    if (base_obs_loc == last_base_states_loc) then
-  !    num_close_states     = last_num_close_states
-  !    close_state_ind(:)  = last_close_state_ind(:)
-  !    close_state_dist(:) = last_close_state_dist(:)
       num_close_states_cached = num_close_states_cached + 1
    else
       call get_close_state(gc_state, base_obs_loc, base_obs_type, &
@@ -2638,8 +2630,6 @@ else
 
       last_base_states_loc      = base_obs_loc
       last_num_close_states     = num_close_states
-    !  last_close_state_ind(:)  = close_state_ind(:)
-    !  last_close_state_dist(:) = close_state_dist(:)
       num_close_states_calls_made = num_close_states_calls_made +1
    endif
 endif

--- a/conf.py
+++ b/conf.py
@@ -21,7 +21,7 @@ copyright = '2021, University Corporation for Atmospheric Research'
 author = 'Data Assimilation Research Section'
 
 # The full version, including alpha/beta/rc tags
-release = '10.0.2'
+release = '10.0.3'
 master_doc = 'README'
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
## Description:
<!--- Describe your changes -->
Removal of redundant caching in the get_close_obs_cached and get_close_state_cached subroutines in DART/assimilation_code/modules/assimilation/assim_tools_mod.f90 . 

- Make close_X arrays intent(inout)
- Remove the explicit caching and copying in `last_close_X_dist = close_X_dist` and `last_close_X_ind = close_X_ind` 
- Remove all other instances of the last_close_X_dist and last_close_X_ind arrays

### Fixes issue
Fixes #364 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

(optimization)

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

### Tests
Tested with WRF, cam-fv, and MPAS_ATM. Test cases can be found in /glade/scratch/hkershaw/DART/siparcs2022/test_cases

The outputs of ensemble runs implementing the revised code proved to be bitwise identical with WRF and cam-fv runs on the main branch. 

WRF and cam-fv were also built with all debugging flags, which did not produce any relevant errors or warnings. 

The revisions did not have any effect on the peak memory usage. 

The removal of the caching greatly reduced the runtime of MPAS_ATM, by about a factor of 3. The runtime of WRF remained consistent with executions on the main branch. The runtime of cam-fv did show some improvement, but it is much smaller than that of MPAS_ATM (improvement of about 40 seconds for an 11 minute run on the main branch). 

The results are detailed below, but note that the runtime does vary slightly across multiple executions. Therefore I have included the results of multiple executions while using the time command.

WRF was run locally using the command `mpirun -n 4 ./filter`
WRF (mpirun -n 4 ./filter, get_close_caching branch)
real	0m3.797s
user	0m11.026s
sys	0m2.190s

real	0m3.335s
user	0m10.114s
sys	0m1.410s

WRF (mpirun -n 4 ./filter, main branch)
real	0m3.424s
user	0m10.477s
sys	0m1.420s

————————————
cam-fv was run on interactive jobs on Cheyenne (select=8:ncpus=36:mpiprocs=36)
cam_fv (./filter, get_close_caching branch)
real	10m19.723s
user	368m17.440s
sys	0m37.255s

real	10m20.472s
user	368m43.953s
sys	0m37.571s

cam_fv (./filter, main branch)
real	11m5.138s
user	395m32.690s
sys	0m36.716s

real	11m2.530s
user	393m58.820s
sys	0m37.390s

————————————
MPAS_ATM was run on interactive jobs on Cheyenne (select=18:ncpus=36:mpiprocs=36)
mpas_atm (./filter, get_close_caching branch)
real	1m21.758s
user	42m53.521s
sys	0m23.436s

real	1m25.355s
user	45m1.992s
sys	0m22.445s

real	1m23.928s
user	44m26.556s
sys	0m21.748s

mpas_atm (./filter, main branch)
real	4m36.890s
user	160m3.367s
sys	0m22.718s

real	4m45.462s
user	165m3.165s
sys	0m23.599s

real	6m35.792s
user	171m29.205s
sys	0m22.464s


## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Version tag 

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [x] Dataset download instructions included
- [ ] No dataset needed

Test cases can be found in the following directories on Cheyenne:
/glade/scratch/hkershaw/DART/siparcs2022/test_cases/wrf
/glade/scratch/hkershaw/DART/siparcs2022/test_cases/CAM/CAM-Run
/glade/scratch/hkershaw/DART/siparcs2022/test_cases/mpas_atm/mpas_test