### PR TITLE
bug-fix: remove obs_utilites_mod from model buildfunctions.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,7 @@ create_ocean_obs
 gitm_blocks_to_netcdf
 gitm_to_netcdf
 netcdf_to_gitm_blocks
+streamflow_obs_diag
 
 # Observation converter exectutables
 convert_aviso

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,13 @@ individual files.
 
 The changes are now listed with the most recent at the top.
 
+**August 18 2022 :: Bug-fixes for obs_utilities build and mpas_atm. Tag: v10.2.1**
+
+- obs_utilities_mod no longer included by default for model/work builds because
+  these utilities are for threed_sphere and threed_cartesian location_mods only.
+- mpas_atm model_mod check for required quantities changed to handle multiple 
+  variables of the same quantity. 
+
 **August 3 2022 :: TIEGCM. Tag v10.2.0**
 
 - TIEGCM model_mod updated to Manhattan

--- a/build_templates/buildfunctions.sh
+++ b/build_templates/buildfunctions.sh
@@ -139,8 +139,7 @@ local misc="$DART/models/utilities/ \
             $DART//observations/forward_operators/obs_def_utilities_mod.f90 \
             $DART/assimilation_code/modules/observations/obs_kind_mod.f90 \
             $DART/assimilation_code/modules/observations/obs_sequence_mod.f90 \
-            $DART/assimilation_code/modules/observations/forward_operator_mod.f90 \
-            $DART/observations/obs_converters/utilities/obs_utilities_mod.f90"
+            $DART/assimilation_code/modules/observations/forward_operator_mod.f90"
 
 # The quantity_mod.f90 files are in assimilation_code/modules/observations
 # so adding individual files from assimilation_code/modules/observations

--- a/conf.py
+++ b/conf.py
@@ -21,7 +21,7 @@ copyright = '2021, University Corporation for Atmospheric Research'
 author = 'Data Assimilation Research Section'
 
 # The full version, including alpha/beta/rc tags
-release = '10.2.0'
+release = '10.2.1'
 master_doc = 'README'
 
 # -- General configuration ---------------------------------------------------

--- a/models/wrf_hydro/work/quickbuild.sh
+++ b/models/wrf_hydro/work/quickbuild.sh
@@ -11,7 +11,8 @@ source "$DART"/build_templates/buildfunctions.sh
 
 MODEL=wrf_hydro
 LOCATION=threed_sphere
-EXTRA="$DART/models/wrf/module_map_utils.f90"
+EXTRA="$DART/models/wrf/module_map_utils.f90 \
+       $DART/observations/obs_converters/utilities/obs_utilities_mod.f90"
 
 
 programs=(


### PR DESCRIPTION
## Description:
<!--- Describe your changes -->
obs_utitiles_mod is only for threed_sphere and threed_cartesian location_mods. 
It should not be included in all model builds.

Remove obs_utilites_mod from model buildfunctions.sh and add to wrf_hydro quickbuild.sh

### Fixes issue
fixes #383

Note this pull request does not make obs_utilities_mod work with all location_mods, just stops  obs_utitlies_mod being compiled into the model programs by default.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

### Tests
build_everything

## Checklist for merging

- [x] Updated changelog entry
- [ ] Documentation updated
- [x] Version tag 

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [x] No dataset needed
