### PR TITLE
bug-fix: mpas_atm call get_num_varids_from_kind to check if a qty is in the state

### DIFF
--- a/models/mpas_atm/model_mod.f90
+++ b/models/mpas_atm/model_mod.f90
@@ -131,7 +131,7 @@ use state_structure_mod, only :  add_domain, get_model_variable_indices, &
                                  state_structure_info, get_index_start, get_index_end, &
                                  get_num_variables, get_domain_size, get_varid_from_varname, &
                                  get_variable_name, get_num_dims, get_dim_lengths, &
-                                 get_dart_vector_index, get_varid_from_kind
+                                 get_dart_vector_index, get_num_varids_from_kind
 
 
 implicit none
@@ -923,12 +923,12 @@ endif
 ! basically we cannot do much without having at least these
 ! three fields in the state vector.  refuse to go further
 ! if these are not present:
-!print *, get_varid_from_kind(anl_domid, QTY_POTENTIAL_TEMPERATURE)
-!print *, get_varid_from_kind(anl_domid, QTY_DENSITY) 
-!print *, get_varid_from_kind(anl_domid, QTY_VAPOR_MIXING_RATIO) 
-if ((get_varid_from_kind(anl_domid, QTY_POTENTIAL_TEMPERATURE) < 0) .or. &
-    (get_varid_from_kind(anl_domid, QTY_DENSITY) < 0) .or. &
-    (get_varid_from_kind(anl_domid, QTY_VAPOR_MIXING_RATIO) < 0)) then
+!print *, get_num_varids_from_kind(anl_domid, QTY_POTENTIAL_TEMPERATURE)
+!print *, get_num_varids_from_kind(anl_domid, QTY_DENSITY)
+!print *, get_num_varids_from_kind(anl_domid, QTY_VAPOR_MIXING_RATIO)
+if ((get_num_varids_from_kind(anl_domid, QTY_POTENTIAL_TEMPERATURE) < 0) .or. &
+    (get_num_varids_from_kind(anl_domid, QTY_DENSITY) < 0) .or. &
+    (get_num_varids_from_kind(anl_domid, QTY_VAPOR_MIXING_RATIO) < 0)) then
    write(string1, *) 'State vector is missing one or more of the following fields:'
    write(string2, *) 'Potential Temperature (theta), Density (rho), Vapor Mixing Ratio (qv).'
    write(string3, *) 'Cannot convert between height/pressure nor compute sensible temps.'


### PR DESCRIPTION
## Description:
<!--- Describe your changes -->
There may be multiple variables with the same qty in the state.
`get_varid_from_kind` errors out if there is more than one variable
of that quantity.
This fix uses `get_num_varids_from_kind` instead

### Fixes issue
<!--- link to github issue(s) -->
fixes #386

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

### Tests
run mpas with these two QTY_POTENTIAL_TEMPERATURE variables in the state.

```
&mpas_vars_nml
  mpas_state_variables =  'theta',  'QTY_POTENTIAL_TEMPERATURE',
                          'th2m',   'QTY_POTENTIAL_TEMPERATURE'
                                         ...
```

## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Version tag 

## Testing Datasets

- [x] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [ ] No dataset needed

/glade/scratch/hkershaw/DART/MPAS/test_run
