### PR TITLE
Add -f option to ln command for POP scripts

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,11 @@ individual files.
 
 The changes are now listed with the most recent at the top.
 
+**September 14 2022 :: Bug-fix for POP shell scripts. Tag: v10.3.1**
+
+- Fixes bug in POP CESM2.1 shell scripts in which inflation files were not
+  being propagated properly due to link destination already existing.
+
 **August 19 2022 :: Automated setup of new model interfaces. Tag: v10.3.0**
 
 - Automated initial setup of new model interfaces to aid users developing

--- a/conf.py
+++ b/conf.py
@@ -21,7 +21,7 @@ copyright = '2021, University Corporation for Atmospheric Research'
 author = 'Data Assimilation Research Section'
 
 # The full version, including alpha/beta/rc tags
-release = '10.3.0'
+release = '10.3.1'
 master_doc = 'README'
 
 # -- General configuration ---------------------------------------------------
@@ -46,7 +46,7 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'models/gitm/testdata1/*
         'guide/history/hawaii_release.rst',
         'guide/history/Guam_release.rst',
         'guide/history/Fiji_release.rst',
-        'guide/Lanai_diffs_from_Kodiak.rst',   
+        'guide/Lanai_diffs_from_Kodiak.rst',
         'guide/history/Jamaica_diffs_from_I.rst',
         'guide/history/pre_j_release.rst',
         'guide/history/PostI_diffs_from_I.rst',
@@ -57,9 +57,9 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'models/gitm/testdata1/*
         'guide/bitwise_considerations.rst',
         'guide/rma.rst',
         'guide/vertical_conversion.rst',
-        'guide/boilerplate/boilerplate.rst',    
-        'guide/boilerplate/template.rst'     
-        
+        'guide/boilerplate/boilerplate.rst',
+        'guide/boilerplate/template.rst'
+
 ]
 
 

--- a/models/POP/shell_scripts/cesm2_1/DART_params.csh
+++ b/models/POP/shell_scripts/cesm2_1/DART_params.csh
@@ -209,7 +209,7 @@ set  nonomatch       # suppress "rm" warnings if wildcard does not match anythin
 
 set  MOVE = 'mv -v'
 set  COPY = 'cp -v --preserve=timestamps'
-set  LINK = 'ln -vs'
+set  LINK = 'ln -vfs'
 set  REMOVE = 'rm -rf' 
 
 exit 0


### PR DESCRIPTION
## Description:
On Cheyenne, the POP assimilate script doesn't propagate the inflation files properly due to the fact that the link command isn't configured to force the reassignment of a symbolic link if the destination is already present. This fix adds the `-f` option when `$LINK` is defined within the scripts to force reassignment of the symbolic link.

### Fixes issue
#392

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Documentation changes needed?
None.

### Tests
Created a test case on Cheyenne to verify that this fixes the problem.
```
cd /glade/work/johnsonb/git/DART_fix_POP/models/POP/shell_scripts/cesm2_1
./setup_CESM_hybrid_ensemble.csh
cd /glade/work/johnsonb/cases/GNYF.f09_g17_e3test
./case.submit -M begin,end
[ ... Case runs to completion without data assimilation ]
./CESM_DART_config.csh
[ ... Configure case to enable data assimilation ]
./xmlchange CONTINUE_RUN=TRUE
./xmlchange STOP_N=1
./xmlchange DATA_ASSIMILATION_CYCLES=3
[ ... Configure case to run for three one-day jobs with assimilate.csh run after each day ]
cd /glade/scratch/johnsonb/GNYF.f09_g17_e3test/run
ls -l input_priorinf_*.nc
lrwxrwxrwx 1 johnsonb ncar 64 Sep  9 16:28 input_priorinf_mean.nc -> GNYF.f09_g17_e3test.pop.output_priorinf_mean.2014-01-06-00000.nc
lrwxrwxrwx 1 johnsonb ncar 62 Sep  9 16:28 input_priorinf_sd.nc -> GNYF.f09_g17_e3test.pop.output_priorinf_sd.2014-01-06-00000.nc
```
The files propagate properly now.

## Checklist for merging

- [x] Updated changelog entry
- [ ] Documentation updated
- [x] Version tag 

## Testing Datasets
Testing can be replicated by using the same commands in the "Tests" section above.