### PR TITLE
bug-fix: add a check for unlimited dimension in read_variables 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,13 @@ individual files.
 
 The changes are now listed with the most recent at the top.
 
+**October 13 2022 :: Bug-fix for read variables. Tag v10.5.3**
+
+- Per-file check for unlimited dimension before variable read. Netcdf 
+  dimension counts adjusted accordingly. Fixes problems when reading from 
+  DART created netcdf files, for example, from fill_inflation_restart
+- Bug-fix for verbose printing of state_structure info
+
 **October 10 2022 :: Bug-fix for obs_converter builds. Tag v10.5.2**
 
 - Bug fix for converter builds using the template model_mod.f90

--- a/assimilation_code/modules/io/direct_netcdf_mod.f90
+++ b/assimilation_code/modules/io/direct_netcdf_mod.f90
@@ -855,6 +855,7 @@ do i = start_var, end_var
    num_dims = get_io_num_dims(domain, i)
    allocate(counts(num_dims))
    allocate(slice_start(num_dims))
+   counts(:) = 1
 
    slice_start(:) = 1 ! default to read all dimensions start at 1
 
@@ -878,7 +879,7 @@ do i = start_var, end_var
 
    else
 
-      counts(:) = get_dim_lengths(domain, i) ! the state
+      counts(1:get_num_dims(domain,i)) = get_dim_lengths(domain, i) ! the state
    endif
 
    ret = nf90_inq_varid(ncfile_in, get_variable_name(domain, i), var_id)
@@ -1585,6 +1586,7 @@ do i = start_var, end_var
       allocate(counts(num_dims))
       allocate(slice_start(num_dims))
       slice_start(:) = 1 ! default to read all dimensions starting at 1
+      counts(:) = 1
 
       if (has_unlimited_dim(domain)) then
 
@@ -1605,8 +1607,9 @@ do i = start_var, end_var
 
       else
 
-         counts(:) = get_dim_lengths(domain, i)
+         counts(1:get_num_dims(domain, i)) = get_dim_lengths(domain, i)
       endif
+
 
 !>@todo FIXME, the first variable in the second domain is not found when using coamps_nest.
       ret = nf90_inq_varid(ncid, trim(get_variable_name(domain, i)), var_id)

--- a/conf.py
+++ b/conf.py
@@ -21,7 +21,7 @@ copyright = '2022, University Corporation for Atmospheric Research'
 author = 'Data Assimilation Research Section'
 
 # The full version, including alpha/beta/rc tags
-release = '10.5.2'
+release = '10.5.3'
 master_doc = 'README'
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
## Description:
<!--- Describe your changes -->

DART created netcdf files vs. model created files do not necessarily have the same netcdf dimensions. 

For DART created files only 'time' gets created as unlimited.  The model netcdf files, e.g. WRF, may have an unlimited dimension 'Time' that is converted limited dimension when DART creates a file from scratch. So if you create an inflation file from scratch with DART `fill_inflation_restart`, it may not match the model template file.

This pull request adds a check to see if the unlimited dimension exists and adjust accordingly before reading netcdf variables.
The bug was introduced in pull request https://github.com/NCAR/DART/pull/374 v10.1.0 for TIEGCM.
The write_variables has the check, but the read_variables was overlooked. 

See https://github.com/NCAR/DART/issues/359#issuecomment-1187818595 for notes on unlimited dimension in dart created files. 

moved the slice_start(:)=1 outside the if statement since both branches set the same value

### Fixes issue
Fixes #402

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

### Tests

Tested using the wrf tutorial  with a smaller number of obs:
`/glade/scratch/hkershaw/DART/Bugs/bug_wrf_netcdf_read/test_dir/rundir`
fill_inflation_restart (create fill from scratch)
fill_inflation_restart (fill in an existing wrfinput file)
run filter with these inflation files (unlimited and limited dimension)

## Checklist for merging

- [x] Updated changelog entry
- [ ] Documentation updated
- [x] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [x] Dataset download instructions included
- [ ] No dataset needed
