### PR TITLE
Removal of unnecessary, expensive array initializations in the MPAS_ATM model_mod.f90

### DIFF
--- a/models/mpas_atm/model_mod.f90
+++ b/models/mpas_atm/model_mod.f90
@@ -1876,8 +1876,6 @@ hor_dist = 1.0e9_r8
 ! Initialize variables to missing status
 
 num_close = 0
-close_ind = -99
-if (present(dist)) dist = 1.0e9_r8   !something big and positive (far away) in radians
 istatus1  = 0
 istatus2  = 0
 
@@ -1991,8 +1989,6 @@ hor_dist = 1.0e9_r8
 ! Initialize variables to missing status
 
 num_close = 0
-close_ind = -99
-if (present(dist)) dist = 1.0e9_r8   !something big and positive (far away) in radians
 istatus1  = 0
 istatus2  = 0
 


### PR DESCRIPTION
## Description:
Removed unnecessary array initializations from get_close_state() and get_close_obs() subroutines in the MPAS_ATM model_mod.f90

`close_ind = -99 `
`if (present(dist)) dist = 1.0e9_r8   !something big and positive (far away) in radians`

Their removal causes a significant reduction to the runtime (can be more than 20%) when running MPAS_ATM cases with large model_size.

See issue for more info.

### Fixes issue
Fixes issue #405 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Performance improvement 

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

### Tests
Tested to be bitwise identical with both Intel and GNU Fortran.
MPAS_ATM was also built and run with all debugging flags, which did not produce any relevant errors or warnings.

For an execution of a high-memory case on Casper (96 ensemble members, 459,985 observations, model_size = 327,759,048), the runtime was reduced from 145 min. to 112 min. or about %23

For an execution of separate mpas_atm case that uses RTTOV observations (10 ensemble members, 77,042 observations, model_size = 109,118,772), the runtime is reduced from 1 min. 9 sec. to 55 sec. or about %20

These test cases are included under Testing Datasets.

## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [x] Dataset download instructions included
- [ ] No dataset needed

Test cases can be found in the following directories on Cheyenne, but any execution of filter with MPAS_ATM will work.

/glade/scratch/masmith/DART/models/mpas_atm/test_run_96ensmembers   (will take over an hour to run)
/glade/scratch/masmith/DART/models/mpas_atm/test_run_5ensmembers   (recommend using this smaller version)
These test cases must be run on the mega-mpas branch.

/glade/scratch/masmith/DART/models/mpas_atm/mpas_rttov_test
This test case can be run on main, but will need to use a specific build template and &preprocess_nml for the RTTOV obs. These can be found at /glade/scratch/masmith/DART/models/mpas_atm/work/rttov_input.nml and /glade/scratch/masmith/DART/build_templates/mkmf.template.rttov.intel