### PR TITLE
move window creation and destruction for perfect_model_obs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,13 @@ individual files.
 
 The changes are now listed with the most recent at the top.
 
+**November 3 2022 :: Bug-fix release. Tag v10.5.4**
+
+- Perfect_model_obs (pmo) fixed for running with MPI and advancing the
+  model inside pmo.
+- MPAS_ATM xtime string padded with blanks for easier bitwise comparison.
+- lorenz_96_tracer_advection quickbuild.sh fixed.
+
 **October 13 2022 :: Bug-fix for read variables. Tag v10.5.3**
 
 - Per-file check for unlimited dimension before variable read. Netcdf 

--- a/assimilation_code/programs/perfect_model_obs/perfect_model_obs.f90
+++ b/assimilation_code/programs/perfect_model_obs/perfect_model_obs.f90
@@ -79,7 +79,6 @@ integer  :: async              = 0
 logical  :: trace_execution    = .false.
 logical  :: output_timestamps  = .false.
 logical  :: silence            = .false.
-logical  :: distributed_state  = .true.
 
 ! if init_time_days and seconds are negative initial time is 0, 0
 ! for no restart or comes from restart if restart exists
@@ -118,7 +117,7 @@ namelist /perfect_model_obs_nml/ read_input_state_from_file, write_output_state_
                                  trace_execution, output_timestamps,                &
                                  print_every_nth_obs, output_forward_op_errors,     &
                                  input_state_files, output_state_files,             &
-                                 single_file_in, single_file_out, distributed_state
+                                 single_file_in, single_file_out
 
 !------------------------------------------------------------------------------
 
@@ -244,11 +243,7 @@ call error_handler(E_MSG,'perfect_main',msgstring)
 
 ! Set up the ensemble storage and read in the restart file
 call trace_message('Before reading in ensemble restart file')
-if(distributed_state) then
-   call init_ensemble_manager(ens_handle, ens_size, model_size)
-else
-   call init_ensemble_manager(ens_handle, ens_size, model_size, transpose_type_in = 2)
-endif
+call init_ensemble_manager(ens_handle, ens_size, model_size)
 
 call set_num_extra_copies(ens_handle, 0)
 

--- a/assimilation_code/programs/perfect_model_obs/perfect_model_obs.f90
+++ b/assimilation_code/programs/perfect_model_obs/perfect_model_obs.f90
@@ -325,9 +325,6 @@ endif
 
 call trace_message('After reading in ensemble restart file')
 
-! Create window for forward operators
-call create_state_window(ens_handle)
-
 !>@todo FIXME this block must be supported in the single file loop with time dimension
 call trace_message('Before initializing output diagnostic file')
 state_meta(1) = 'true state'
@@ -480,6 +477,9 @@ AdvanceTime: do
    write(msgstring, '(A,I8,A)') 'Ready to evaluate up to', size(keys), ' observations'
    call trace_message(msgstring, 'perfect_model_obs:', -1)
 
+   ! Set up access to the state
+   call create_state_window(ens_handle)
+
    ! Compute the forward observation operator for each observation in set
    do j = 1, fwd_op_ens_handle%my_num_vars
 
@@ -575,6 +575,8 @@ AdvanceTime: do
 
    endif
 
+   ! End access to the state
+   call free_state_window(ens_handle)
 
    ! Deallocate the keys storage
    deallocate(keys)
@@ -612,9 +614,6 @@ endif
 
 call trace_message('After  writing state restart file if requested')
 call trace_message('Before ensemble and obs memory cleanup')
-
-! Close the windows
-call free_state_window(ens_handle)
 
 !  Release storage for ensemble
 call end_ensemble_manager(ens_handle)

--- a/assimilation_code/programs/perfect_model_obs/perfect_model_obs.nml
+++ b/assimilation_code/programs/perfect_model_obs/perfect_model_obs.nml
@@ -10,7 +10,6 @@
    output_state_files         = "",
    output_interval            = 1,
 
-   distributed_state          = .false.,
    async                      = 0,
    adv_ens_command            = "./advance_model.csh",
    tasks_per_model_advance    = 1,

--- a/assimilation_code/programs/perfect_model_obs/perfect_model_obs.rst
+++ b/assimilation_code/programs/perfect_model_obs/perfect_model_obs.rst
@@ -30,7 +30,6 @@ namelist.
       write_output_state_to_file = .false.,
       output_interval            = 1,
 
-      distributed_state          = .false.,
       async                      = 0,
       adv_ens_command            = "./advance_model.csh",
       tasks_per_model_advance    = 1,
@@ -86,15 +85,6 @@ namelist.
    | output_interval                       | integer                               | Output state and observation          |
    |                                       |                                       | diagnostics every nth assimilation    |
    |                                       |                                       | time, n is output_interval.           |
-   +---------------------------------------+---------------------------------------+---------------------------------------+
-   | distributed_state                     | logical                               | True means the ensemble data is       |
-   |                                       |                                       | distributed across all tasks as it is |
-   |                                       |                                       | read in, so a single task never has   |
-   |                                       |                                       | to have enough memory to store the    |
-   |                                       |                                       | data for an ensemble member. Large    |
-   |                                       |                                       | models should always set this to      |
-   |                                       |                                       | .true., while for small models it may |
-   |                                       |                                       | be faster to set this to .false.      |
    +---------------------------------------+---------------------------------------+---------------------------------------+
    | async                                 | integer                               | Controls method for advancing model:  |
    |                                       |                                       |                                       |

--- a/conf.py
+++ b/conf.py
@@ -21,7 +21,7 @@ copyright = '2022, University Corporation for Atmospheric Research'
 author = 'Data Assimilation Research Section'
 
 # The full version, including alpha/beta/rc tags
-release = '10.5.3'
+release = '10.5.4'
 master_doc = 'README'
 
 # -- General configuration ---------------------------------------------------

--- a/models/POP/work/input.nml
+++ b/models/POP/work/input.nml
@@ -25,7 +25,6 @@
    print_every_nth_obs        = -1
    output_forward_op_errors   = .false.
    silence                    = .false.
-   distributed_state          = .true.
   /
 
 &filter_nml


### PR DESCRIPTION
## Description:
Perfect_model_obs was giving incorrect obs_seq.out (forward operators) when the  model was advanced in perfect_model_obs **and** perfect_model_obs was run with multiple processors (using the default namelist option of `distributed_state = .true.`)

This pull request moves the mpi window creation and destruction for perfect_model_obs inside the AdvanceTime do loop. The forward operator needs to use state from each step of the loop, so the window must be recreated.

Why do we need to create a window each time? Because currently the mpi window is created using a copy of the state. 

Edit:
This pull request also removes the namelist option `distribute_state` from pmo.
The perfect_model_obs code is not setup to do non-distrbuted state foward operators - the obs loop is around my_num_vars. Compare this to foward_operator_mod::get_obs_ens_distributed_state which has an if statement for transposed or distributed state forward operators. 

### Fixes issue
fixes #417

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

### Tests
Please describe any tests you ran to verify your changes.

Lorenz_96 perfect_model obs. serial, and mpirun n=4 give the same obs_seq.out and same true_state.nc

## Checklist for merging

- [x] Updated changelog entry
- [ ] Documentation updated
- [x] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [x] No dataset needed

  ### Notes 
  still to test if `distributed_state = .false.` works correctly. 