### PR TITLE
fix: fill_inflation_restart (re)added to default builds for clm

### DIFF
--- a/models/clm/work/quickbuild.sh
+++ b/models/clm/work/quickbuild.sh
@@ -17,13 +17,13 @@ programs=(
 filter
 model_mod_check
 perfect_model_obs
-perturb_single_instance
 )
 
 serial_programs=(
 advance_time
 create_fixed_network_seq
 create_obs_sequence
+fill_inflation_restart
 obs_diag
 obs_seq_to_netcdf
 obs_sequence_tool


### PR DESCRIPTION
## Description:
<!--- Describe your changes -->

The conversion from mkfmf_* quickbuld.csh to quickbuild.sh missed fill_inflation_restart for clm.

This pull request:
* adds fill_inflation_restart to the default list of programs for clm.
* removes perturb_single_instance since clm cannot be perturbed from a single ensemble member.
The quickbuild.sh list of programs now matches the v9.16.4 list.

### Fixes issue
No issue, user reported this weekend to dart email. The user was working through the The CLM-DART tutorial which uses fill_inflation_restart.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

### Tests
Please describe any tests you ran to verify your changes.
Built clm programs, checked the list of programs against v9.16.4 mkmf_*

## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [ ] No dataset needed
