### PR TITLE
move code to set ptype variable outside the if() statement

### DIFF
--- a/models/cam-fv/model_mod.f90
+++ b/models/cam-fv/model_mod.f90
@@ -2077,18 +2077,21 @@ character(len=*), parameter :: routine = 'obs_vertical_to_scaleheight'
 
 ens_size = 1
 
+! if this location is on the surface, use the surface pressure field
+! in the computations below.  otherwise use the 3d pressure field.
+if (query_location(location) == VERTISSURFACE) then
+   ptype = QTY_SURFACE_PRESSURE
+else
+   ptype = QTY_PRESSURE
+endif
+
+
 ! there are 4 cases here.
 
 if (no_normalization_of_scale_heights) then
 
    ! take log of pressure, either surface pressure or regular pressure
    
-   if (query_location(location) == VERTISSURFACE) then
-      ptype = QTY_SURFACE_PRESSURE
-   else
-      ptype = QTY_PRESSURE
-   endif
-
    call ok_to_interpolate(ptype, varid1, my_status)
    if (my_status /= 0) return
       


### PR DESCRIPTION
in the cam model_mod, referencing an unset ptype in the else clause could cause a crash.

## Description:
fixes bug #381.  this update moves the setting of the ptype variable outside the if() statement so it doesn't crash with an unset variable in the else clause.

in the bug report discussion there was mention of other changes but i believe the decision was that more extensive refactoring was outside the scope of this bug and we should fix this immediate issue only.

### Fixes issue
#381

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

### Tests
i ran helen's test case and it no longer crashes.

## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ x] Dataset download instructions included - helen has one in the original bug report.
- [ ] No dataset needed
