### PR TITLE
do not allow convert_all_obs_verticals_first to be false

### DIFF
--- a/assimilation_code/modules/assimilation/assim_tools_mod.f90
+++ b/assimilation_code/modules/assimilation/assim_tools_mod.f90
@@ -292,6 +292,15 @@ endif
 
 is_doing_vertical_conversion = (has_vertical_choice() .and. vertical_localization_on())
 
+! this option is deprecated and will be removed in some future release.
+if (.not. convert_all_obs_verticals_first) then
+   call error_handler(E_ERR,'assim_tools_init:', &
+                      'namelist item "convert_all_obs_verticals_first" is deprecated and will be removed in a future release', &
+                      source, &
+                      text2='it must have a value of .true. or be removed from the &assim_tools_nml namelist')
+   
+endif
+
 call log_namelist_selections(num_special_cutoff, cache_override)
 
 end subroutine assim_tools_init


### PR DESCRIPTION
drop support for letting get_close do lazy vertical conversion on observations.   test if this namelist item is false and error out.  the default is true so users setting this to false seems unlikely.  but it shouldn't be left there because it results in wrong DART QCs in the output file.   eventually this option should be deprecated and removed from the namelist.

## Description:
<!--- Describe your changes -->
add a check for a user setting this namelist false and error out with a message.

### Fixes issue
#426

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

### Tests
set convert_all_obs_verticals_first to false in the namelist and run filter on anything.

## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [x ] No dataset needed
