### PR TITLE
Edit cam-fv assimilate.csh.template to improve purge logic for restarts

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,12 @@ individual files.
 
 The changes are now listed with the most recent at the top.
 
+**December 2 2022 :: Bug-fix cam-fv. Tag v10.5.6**
+
+- Fix for assimilate.csh purge of restart files when the interval for restart
+  saves is given as a string rather than an integer.
+- Fix for setting ptype when no_normalization_of_scale_heights = .false.
+
 **November 8 2022 :: Improved clean_nml and CLM quickbuild.sh. Tag v10.5.5**
 
 - clean_nml tool for comparing input.nmls given optional arguments to 

--- a/conf.py
+++ b/conf.py
@@ -21,7 +21,7 @@ copyright = '2022, University Corporation for Atmospheric Research'
 author = 'Data Assimilation Research Section'
 
 # The full version, including alpha/beta/rc tags
-release = '10.5.5'
+release = '10.5.6'
 master_doc = 'README'
 
 # -- General configuration ---------------------------------------------------

--- a/models/cam-fv/shell_scripts/cesm2_1/assimilate.csh.template
+++ b/models/cam-fv/shell_scripts/cesm2_1/assimilate.csh.template
@@ -356,6 +356,24 @@ if ($#log_list >= 3) then
    set sec_o_day   = $RM_DATE_PARTS[4]
    set day_time    = ${day_o_month}-${sec_o_day}
 
+   # Decide whether to purge restart files at this date and time.
+   set save_rest_freq = BOGUS_save_every_Mth
+
+   set purge = 'true'
+   # Learn whether save_rest_freq a string or a number.
+   # Character strings must be tested outside of the 'if' statement.
+   echo $save_rest_freq | grep '[a-z]'
+   if ($status == 0) then
+      set purge_date = $RM_DATE_PARTS[1]-$RM_DATE_PARTS[2]-$RM_DATE_PARTS[3]
+      set weekday = `date --date="$purge_date" +%A`
+      if ($weekday == $save_rest_freq) set purge = 'false'
+ 
+   # Numbers can be tested inside the 'if' statement.
+   else if (`echo $save_rest_freq | grep '[0-9]'`) then
+      if (${day_o_month} % ${save_rest_freq} == 0) set purge = 'false'
+ 
+   endif
+
    # Identify log files to be removed or moved.
    # [3] means the 3rd oldest restart set is being (re)moved.
    set rm_log = `echo $log_list[3] | sed -e "s/\./ /g;"`
@@ -367,7 +385,7 @@ if ($#log_list >= 3) then
    # The 'else' block preserves the restarts in the archive directory.
 
    if ( $sec_o_day !~ '00000' || \
-       ($sec_o_day =~ '00000' && $day_o_month % BOGUS_save_every_Mth != 0) ) then
+       ($sec_o_day =~ '00000' && $purge == 'true') ) then
 
       # Optionally save inflation restarts, even if it's not a 'save restart' time.
       if ($save_all_inf =~ TRUE) ${MOVE} ${CASE}*inf*${day_time}*  ${archive}/esp/hist


### PR DESCRIPTION
## Description:
This modification of the assimilate.csh.template for cam-fv fixes the issue in which restart files sometimes aren't being purged when the interval between restart saves is a string rather than an integer.

### Fixes issue

fixes #435  

### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Documentation changes needed?
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

### Tests
Set up a FHIST run on the `f09_g17` grid and cycled for two weeks to ensure that this change fixes the issue.

## Checklist for merging

- [x] Updated changelog entry
- [ ] Documentation updated
- [x] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [ ] No dataset needed
