### PR TITLE
Fix broken link in DART tutorial

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,11 @@ individual files.
 
 The changes are now listed with the most recent at the top.
 
+**December 20 2022 :: Bug-fix for broken link in DART Tutorial. Tag v10.6.1**
+
+- Fixes a link within the documentation to a section describing how to
+  configure MATLAB's path to use DART MATLAB functions.
+
 **December 12 2022 :: Automated testing of pull requests**
 
 - GitHub actions for pull requests which checkout, compile and run a 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,12 +22,13 @@ individual files.
 
 The changes are now listed with the most recent at the top.
 
-**December 20 2022 :: Bug-fix for broken link in DART Tutorial. Tag v10.6.1**
+**December 21 2022 :: Documentation update for CLM and the DART Tutorial. Tag v10.6.1**
 
-- Fixes a link within the documentation to a section describing how to
+- Improved instructions for the CLM-DART tutorial.  
+- Fixes link within the documentation to a section describing how to
   configure MATLAB's path to use DART MATLAB functions.
 
-**December 12 2022 :: Automated testing of pull requests**
+**December 12 2022 :: Automated testing of pull requests. Tag v10.6.0**
 
 - GitHub actions for pull requests which checkout, compile and run a 
   given model.  

--- a/conf.py
+++ b/conf.py
@@ -21,7 +21,7 @@ copyright = '2022, University Corporation for Atmospheric Research'
 author = 'Data Assimilation Research Section'
 
 # The full version, including alpha/beta/rc tags
-release = '10.6.0'
+release = '10.6.1'
 master_doc = 'README'
 
 # -- General configuration ---------------------------------------------------

--- a/guide/matlab-observation-space.rst
+++ b/guide/matlab-observation-space.rst
@@ -1,9 +1,27 @@
-#####################################
-MATLAB® observation space diagnostics
-#####################################
+####################################
+MATLAB observation space diagnostics
+####################################
 
-The observation-space functions are in the ``$DARTROOT/diagnostics/matlab``
-directory. Once you have processed the ``obs_seq.final`` files into a single
+Configuring MATLAB
+==================
+
+DART uses MATLAB's own netCDF reading and writing capability and does not use
+any MATLAB or third-party toolboxes. 
+
+To allow your environment to seamlessly use the DART MATLAB functions, your
+MATLAB path must be set to include two of the directories in the DART
+repository. In the MATLAB command prompt enter the following, using the real
+path to your DART installation:
+
+.. code-block::
+
+   addpath('DART/diagnostics/matlab','-BEGIN')
+   addpath('DART/guide/DART_LAB/matlab','-BEGIN')
+
+Summary of MATLAB functions
+===========================
+
+Once you have processed the ``obs_seq.final`` files into a single
 ``obs_diag_output.nc``, you can use that as input to your own plotting routines
 or use the following DART MATLAB® routines:
 
@@ -241,3 +259,4 @@ the selected observations get highlighted there too.
 
 .. |link obs example frame 0| image:: images/science_nuggets/link_obs_example_F0.png
    :width: 100%
+

--- a/guide/matlab-observation-space.rst
+++ b/guide/matlab-observation-space.rst
@@ -18,6 +18,11 @@ path to your DART installation:
    addpath('DART/diagnostics/matlab','-BEGIN')
    addpath('DART/guide/DART_LAB/matlab','-BEGIN')
 
+It is convenient to put these commands in your ``~/matlab/startup.m`` so they
+get run every time MATLAB starts up. You can use the example ``startup.m`` file
+located at ``DART/diagnostics/matlab/startup.m``. This example startup file
+contains instructions for using it.
+
 Summary of MATLAB functions
 ===========================
 

--- a/theory/readme.rst
+++ b/theory/readme.rst
@@ -10,8 +10,7 @@ prerequisite statistical concepts by reading
 
 The diagnostics in the tutorial use Matlab®. To learn how to configure your
 environment to use Matlab and the DART diagnostics, see the documentation for
-`Configuring Matlab® for netCDF & DART
-<http://www.image.ucar.edu/DAReS/DART/DART2_Documentation.php#configure_matlab>`__.
+:doc:`/guide/matlab-observation-space`.
 
 - **Section  1:** `Filtering For a One Variable System                                                                         <../_static/slides/section_01.pdf>`__ 
 - **Section  2:** `The DART Directory Tree                                                                                     <../_static/slides/section_02.pdf>`__ 


### PR DESCRIPTION
## Description:

There's a broken link on the DART Tutorial page for Configuring Matlab® for netCDF & DART:

https://raw.githubusercontent.com/NCAR/DART/v10.6.0/theory/readme.rst

### Fixes issue

fixes #441  

### Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation update

### Documentation changes needed?

- [X] My change requires a change to the documentation.
  - [X] I have updated the documentation accordingly.

### Tests

I rebuilt the documentation using Sphinx to check that the two edited pages render correctly.

## Checklist for merging

- [x] Updated changelog entry
- [X] Documentation updated
- [X] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [X] No dataset needed
