### PR TITLE
Bugfix QC8

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,13 @@ individual files.
 
 The changes are now listed with the most recent at the top.
 
+**February 9 2023 :: Bug-fix for vertical conversion QC 8. Tag v10.6.3**
+
+- QC 8 values now correctly recorded. Previously this info was lost if 
+  the posterior FO was skipped.  
+- Fixes QC overwrite for forward operators when running distributed_state = .false.
+- WRF tutorial bug fix for setting paramfile.
+
 **January 27 2023 :: Documentation update for porting new models. Tag v10.6.2**
 
 - Improved 'porting new models to DART' documentation.

--- a/assimilation_code/modules/assimilation/filter_mod.f90
+++ b/assimilation_code/modules/assimilation/filter_mod.f90
@@ -1051,6 +1051,10 @@ AdvanceTime : do
    
       call trace_message('After  posterior obs space diagnostics')
    else
+      ! call this alternate routine to collect any updated QC values that may
+      ! have been set in the assimilation loop and copy them to the outgoing obs seq
+      call obs_space_sync_QCs(obs_fwd_op_ens_handle, seq, keys, num_obs_in_set, &
+                              OBS_GLOBAL_QC_COPY, DART_qc_index)
       call deallocate_single_copy(obs_fwd_op_ens_handle, prior_qc_copy)
    endif
 
@@ -1663,7 +1667,7 @@ subroutine obs_space_diagnostics(obs_fwd_op_ens_handle, qc_ens_handle, ens_size,
    OBS_MEAN_START, OBS_VAR_START, OBS_GLOBAL_QC_COPY, OBS_VAL_COPY, &
    OBS_ERR_VAR_COPY, DART_qc_index, do_post)
 
-! Do prior observation space diagnostics on the set of obs corresponding to keys
+! Do observation space diagnostics on the set of obs corresponding to keys
 
 type(ensemble_type),     intent(inout) :: obs_fwd_op_ens_handle, qc_ens_handle
 integer,                 intent(in)    :: ens_size
@@ -1758,6 +1762,56 @@ endif
 deallocate(obs_temp)
 
 end subroutine obs_space_diagnostics
+
+!-------------------------------------------------------------------------
+
+subroutine obs_space_sync_QCs(obs_fwd_op_ens_handle,  &
+   seq, keys, num_obs_in_set, OBS_GLOBAL_QC_COPY, DART_qc_index)
+
+! If QCs were updated in the assimilation loop but posterior forward operators
+! are not being computed, collect any updated QCs into the output obs_seq.
+
+type(ensemble_type),     intent(inout) :: obs_fwd_op_ens_handle
+integer,                 intent(in)    :: num_obs_in_set
+integer,                 intent(in)    :: keys(num_obs_in_set)
+type(obs_sequence_type), intent(inout) :: seq
+integer,                 intent(in)    :: OBS_GLOBAL_QC_COPY
+integer,                 intent(in)    :: DART_qc_index
+
+integer               :: j
+integer               :: io_task, my_task
+real(r8), allocatable :: obs_temp(:)
+real(r8)              :: rvalue(1)
+
+! this is a query routine to return which task has 
+! logical processing element 0 in this ensemble.
+io_task = map_pe_to_task(obs_fwd_op_ens_handle, 0)
+my_task = my_task_id()
+
+! Make var complete for get_copy() calls below.
+! Optimize: Could we use a gather instead of a transpose and get copy?
+call all_copies_to_all_vars(obs_fwd_op_ens_handle)
+
+! allocate temp space for sending data only on the task that will
+! write the obs_seq.final file
+if (my_task == io_task) then
+   allocate(obs_temp(num_obs_in_set))
+else ! TJH: this change became necessary when using Intel 19.0.5 ...
+   allocate(obs_temp(1))
+endif
+
+! Update the qc global value
+call get_copy(io_task, obs_fwd_op_ens_handle, OBS_GLOBAL_QC_COPY, obs_temp)
+if(my_task == io_task) then
+   do j = 1, obs_fwd_op_ens_handle%num_vars
+      rvalue(1) = obs_temp(j)
+      call replace_qc(seq, keys(j), rvalue, DART_qc_index)
+   end do
+endif
+
+deallocate(obs_temp)
+
+end subroutine obs_space_sync_QCs
 
 !-------------------------------------------------------------------------
 

--- a/assimilation_code/modules/assimilation/filter_mod.f90
+++ b/assimilation_code/modules/assimilation/filter_mod.f90
@@ -1788,10 +1788,6 @@ real(r8)              :: rvalue(1)
 io_task = map_pe_to_task(obs_fwd_op_ens_handle, 0)
 my_task = my_task_id()
 
-! Make var complete for get_copy() calls below.
-! Optimize: Could we use a gather instead of a transpose and get copy?
-call all_copies_to_all_vars(obs_fwd_op_ens_handle)
-
 ! allocate temp space for sending data only on the task that will
 ! write the obs_seq.final file
 if (my_task == io_task) then
@@ -1799,6 +1795,9 @@ if (my_task == io_task) then
 else ! TJH: this change became necessary when using Intel 19.0.5 ...
    allocate(obs_temp(1))
 endif
+
+! Optimize: Could we use a gather instead of a transpose and get copy?
+call all_copies_to_all_vars(obs_fwd_op_ens_handle)
 
 ! Update the qc global value
 call get_copy(io_task, obs_fwd_op_ens_handle, OBS_GLOBAL_QC_COPY, obs_temp)

--- a/assimilation_code/modules/assimilation/filter_mod.f90
+++ b/assimilation_code/modules/assimilation/filter_mod.f90
@@ -1768,8 +1768,6 @@ end subroutine obs_space_diagnostics
 subroutine obs_space_sync_QCs(obs_fwd_op_ens_handle,  &
    seq, keys, num_obs_in_set, OBS_GLOBAL_QC_COPY, DART_qc_index)
 
-! If QCs were updated in the assimilation loop but posterior forward operators
-! are not being computed, collect any updated QCs into the output obs_seq.
 
 type(ensemble_type),     intent(inout) :: obs_fwd_op_ens_handle
 integer,                 intent(in)    :: num_obs_in_set
@@ -1788,11 +1786,10 @@ real(r8)              :: rvalue(1)
 io_task = map_pe_to_task(obs_fwd_op_ens_handle, 0)
 my_task = my_task_id()
 
-! allocate temp space for sending data only on the task that will
 ! write the obs_seq.final file
 if (my_task == io_task) then
    allocate(obs_temp(num_obs_in_set))
-else ! TJH: this change became necessary when using Intel 19.0.5 ...
+else 
    allocate(obs_temp(1))
 endif
 

--- a/assimilation_code/modules/observations/forward_operator_mod.f90
+++ b/assimilation_code/modules/observations/forward_operator_mod.f90
@@ -323,8 +323,6 @@ if (get_allow_transpose(ens_handle)) then
    ! each ensemble member into global_qc_value
    allocate(var_istatus(qc_ens_handle%num_copies))
 
-   if (.not. isprior) call put_single_copy(obs_fwd_op_ens_handle, OBS_GLOBAL_QC_COPY, prior_qc_copy)
-
    MY_OBS: do j = 1,  obs_fwd_op_ens_handle%my_num_vars
       ! collect dart qc
       var_istatus = qc_ens_handle%copies(:,j) 

--- a/assimilation_code/modules/observations/forward_operator_mod.f90
+++ b/assimilation_code/modules/observations/forward_operator_mod.f90
@@ -133,7 +133,7 @@ expected_obs = MISSING_R8
 ! call prepare_to_read_from_vars(ens_handle)
 
 ! Set up access to the state
-call create_state_window(ens_handle)
+call create_state_window(ens_handle, obs_fwd_op_ens_handle, qc_ens_handle)
 
 ens_size = ens_handle%num_copies - ens_handle%num_extras
 

--- a/assimilation_code/modules/utilities/cray_win_mod.f90
+++ b/assimilation_code/modules/utilities/cray_win_mod.f90
@@ -54,9 +54,11 @@ contains
 !-------------------------------------------------------------
 !> Create the window for the ensemble complete state vector
 !> I think you have to pass it the state ensemble handle
-subroutine create_state_window(state_ens_handle)
+subroutine create_state_window(state_ens_handle, fwd_op_ens_handle, qc_ens_handle)
 
 type(ensemble_type), intent(inout) :: state_ens_handle !< state ensemble handle
+type(ensemble_type), intent(inout), optional :: fwd_op_ens_handle
+type(ensemble_type), intent(inout), optional :: qc_ens_handle
 
 integer :: ii, jj, count, ierr
 integer :: bytesize !< size in bytes of each element in the window
@@ -68,6 +70,12 @@ data_count = copies_in_window(state_ens_handle)
 
 if (get_allow_transpose(state_ens_handle)) then
    call all_copies_to_all_vars(state_ens_handle)
+   if (present(fwd_op_ens_handle)) then
+      call all_copies_to_all_vars(fwd_op_ens_handle)
+   endif
+   if (present(qc_ens_handle)) then
+      call all_copies_to_all_vars(qc_ens_handle)
+   endif
 else
    ! find how many variables I have
    my_num_vars = state_ens_handle%my_num_vars

--- a/assimilation_code/modules/utilities/no_cray_win_mod.f90
+++ b/assimilation_code/modules/utilities/no_cray_win_mod.f90
@@ -55,9 +55,11 @@ contains
 !> For the non-distributed case this is simply a transpose
 !> For the distributed case memory is allocated in this module
 !> then an mpi window is attached to this memory.
-subroutine create_state_window(state_ens_handle)
+subroutine create_state_window(state_ens_handle, fwd_op_ens_handle, qc_ens_handle)
 
 type(ensemble_type), intent(inout) :: state_ens_handle
+type(ensemble_type), intent(inout), optional :: fwd_op_ens_handle
+type(ensemble_type), intent(inout), optional :: qc_ens_handle
 
 integer :: ierr
 integer :: bytesize !< size in bytes of each element in the window
@@ -69,6 +71,12 @@ data_count = copies_in_window(state_ens_handle)
 
 if (get_allow_transpose(state_ens_handle)) then
    call all_copies_to_all_vars(state_ens_handle)
+   if (present(fwd_op_ens_handle)) then
+      call all_copies_to_all_vars(fwd_op_ens_handle)
+   endif
+   if (present(qc_ens_handle)) then
+      call all_copies_to_all_vars(qc_ens_handle)
+   endif
 else
    ! find how many variables I have
    my_num_vars = state_ens_handle%my_num_vars

--- a/assimilation_code/modules/utilities/null_win_mod.f90
+++ b/assimilation_code/modules/utilities/null_win_mod.f90
@@ -38,9 +38,11 @@ contains
 
 !-------------------------------------------------------------
 !> Always using distributed in non-mpi case
-subroutine create_state_window(state_ens_handle)
+subroutine create_state_window(state_ens_handle, fwd_op_ens_handle, qc_ens_handle)
 
 type(ensemble_type), intent(inout) :: state_ens_handle
+type(ensemble_type), intent(inout), optional :: fwd_op_ens_handle
+type(ensemble_type), intent(inout), optional :: qc_ens_handle
 
 ! Find out how many copies to put in the window
 ! copies_in_window is not necessarily equal to ens_handle%num_copies

--- a/conf.py
+++ b/conf.py
@@ -21,7 +21,7 @@ copyright = '2022, University Corporation for Atmospheric Research'
 author = 'Data Assimilation Research Section'
 
 # The full version, including alpha/beta/rc tags
-release = '10.6.2'
+release = '10.6.3'
 master_doc = 'README'
 
 # -- General configuration ---------------------------------------------------

--- a/models/wrf/shell_scripts/gen_retro_icbc.csh
+++ b/models/wrf/shell_scripts/gen_retro_icbc.csh
@@ -43,7 +43,6 @@ echo "gen_retro_icbc.csh is running in `pwd`"
 set datea     = 2017042700
 set datefnl   = 2017042712 # set this appropriately #%%%#
 set paramfile = /glade2/scratch2/USERNAME/WORK_DIR/scripts/param.csh   # set this appropriately #%%%#
-set paramfile = /glade/work/thoar/DART/clean_rma_trunk/models/wrf/tutorial/scripts/param.csh
 
 source $paramfile
 


### PR DESCRIPTION
## Description:
There are several bugs in the QC handling that cause the DART QC data to be overwritten or lost. Specifically, the value for DARTQC_FAILED_VERT_CONVERT (8) was not ending up in the obs_seq.final after forcing convert_vertical_obs to return a failing vstatus. 

This pull request:
- Fixes the QC data being overwritten in obs_fwd_op_ens_handle%copies in the transpose from vars to copies in free_state_window() at line 310 forward_operator_mod
- Removes a misplaced call to put_single_copy() that also overwrites the QC data in obs_fwd_op_ens_handle%copies
- Includes @nancycollins fix for the QC values being lost if posterior FOs are not being computed (compute_posterior=.false.) (see PR #430) 

### Fixes issue
Fixes the multiple bugs in issue #401 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

### Tests
Tested with cam-fv and wrf; runs of filter with the implemented bug-fixes are bitwise identical, both with the vertical conversion set to fail (forcing all QC values to 8) and the original QC values. The fixes have also been tested with each possible configuration for the nml options of compute_posterior and distributed_state.

## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [x] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [ ] No dataset needed
