### PR TITLE
wrf tutorial fix: remove unnecessary and misleading second 'set paramfile' in gen_retro_icbc.csh

### DIFF
--- a/models/wrf/shell_scripts/gen_retro_icbc.csh
+++ b/models/wrf/shell_scripts/gen_retro_icbc.csh
@@ -43,7 +43,6 @@ echo "gen_retro_icbc.csh is running in `pwd`"
 set datea     = 2017042700
 set datefnl   = 2017042712 # set this appropriately #%%%#
 set paramfile = /glade2/scratch2/USERNAME/WORK_DIR/scripts/param.csh   # set this appropriately #%%%#
-set paramfile = /glade/work/thoar/DART/clean_rma_trunk/models/wrf/tutorial/scripts/param.csh
 
 source $paramfile
 


### PR DESCRIPTION
## Description:
<!--- Describe your changes -->
We have had a couple of users hit problems when running the wrf tutorial 
This pull request fixes one of the common issues, a second setting of paramfile which can be easily missed in
`gen_retro_icbc.csh` 

### Fixes issue
<!--- link to github issue(s) -->
fixes the first problem in #295

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

### Tests
Run `./gen_retro_icbc.csh` , check `source $paramfile` is using the paramfile I set.

## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [x] No dataset needed
