### PR TITLE
remove  state_ens_handle  from adaptive_inflate_init arguments

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,13 @@ individual files.
 
 The changes are now listed with the most recent at the top.
 
+**February 22 2023 :: Bug-fix release. Tag v10.6.4**
+
+- Removes unused and uninitialized argument to adaptive_inflate_init.
+- Fixes HDF5_utilities_mod i4 i8 mismatch.
+- Removes HDF tutorial code which is not part of DART.
+- Fixes misleading comment in filter_mod.f90
+
 **February 9 2023 :: Bug-fix for vertical conversion QC 8. Tag v10.6.3**
 
 - QC 8 values now correctly recorded. Previously this info was lost if 

--- a/assimilation_code/modules/assimilation/adaptive_inflate_mod.f90
+++ b/assimilation_code/modules/assimilation/adaptive_inflate_mod.f90
@@ -220,7 +220,7 @@ end function do_ss_inflate
 subroutine adaptive_inflate_init(inflate_handle, inf_flavor, mean_from_restart, &
    sd_from_restart, output_inflation, deterministic, & 
    inf_initial, sd_initial, inf_lower_bound, inf_upper_bound, &
-   sd_lower_bound, sd_max_change, ens_handle, missing_ok, label)
+   sd_lower_bound, sd_max_change, missing_ok, label)
 
 type(adaptive_inflate_type), intent(inout) :: inflate_handle
 integer,                     intent(in)    :: inf_flavor
@@ -232,7 +232,6 @@ real(r8),                    intent(in)    :: inf_initial, sd_initial
 real(r8),                    intent(in)    :: inf_lower_bound, inf_upper_bound
 real(r8),                    intent(in)    :: sd_lower_bound
 real(r8),                    intent(in)    :: sd_max_change
-type(ensemble_type),         intent(inout) :: ens_handle
 logical,                     intent(in)    :: missing_ok
 character(len = *),          intent(in)    :: label
 

--- a/assimilation_code/modules/assimilation/filter_mod.dopplerfold.f90
+++ b/assimilation_code/modules/assimilation/filter_mod.dopplerfold.f90
@@ -417,7 +417,6 @@ call adaptive_inflate_init(prior_inflate, &
                            inf_upper_bound(PRIOR_INF), &
                            inf_sd_lower_bound(PRIOR_INF), &
                            inf_sd_max_change(PRIOR_INF), &
-                           state_ens_handle, &
                            allow_missing, 'Prior')
 
 call adaptive_inflate_init(post_inflate, &
@@ -432,7 +431,6 @@ call adaptive_inflate_init(post_inflate, &
                            inf_upper_bound(POSTERIOR_INF), &
                            inf_sd_lower_bound(POSTERIOR_INF), &
                            inf_sd_max_change(POSTERIOR_INF), &
-                           state_ens_handle, &
                            allow_missing, 'Posterior')
 
 if (do_output()) then

--- a/assimilation_code/modules/assimilation/filter_mod.dopplerfold.f90
+++ b/assimilation_code/modules/assimilation/filter_mod.dopplerfold.f90
@@ -189,7 +189,7 @@ logical  :: output_timestamps        = .false.
 logical  :: trace_execution          = .false.
 logical  :: write_obs_every_cycle    = .false.  ! debug only
 logical  :: silence                  = .false.
-logical  :: distributed_state = .true. ! Default to do state complete forward operators.
+logical  :: distributed_state = .true. ! Default to do distributed forward operators.
 
 ! IO options
 !>@todo FIXME - how does this work for multiple domains?  ens1d1, ens2d1, ... ens1d2 or

--- a/assimilation_code/modules/assimilation/filter_mod.f90
+++ b/assimilation_code/modules/assimilation/filter_mod.f90
@@ -412,7 +412,6 @@ call adaptive_inflate_init(prior_inflate, &
                            inf_upper_bound(PRIOR_INF), &
                            inf_sd_lower_bound(PRIOR_INF), &
                            inf_sd_max_change(PRIOR_INF), &
-                           state_ens_handle, &
                            allow_missing, 'Prior')
 
 call adaptive_inflate_init(post_inflate, &
@@ -427,7 +426,6 @@ call adaptive_inflate_init(post_inflate, &
                            inf_upper_bound(POSTERIOR_INF), &
                            inf_sd_lower_bound(POSTERIOR_INF), &
                            inf_sd_max_change(POSTERIOR_INF), &
-                           state_ens_handle, &
                            allow_missing, 'Posterior')
 
 if (do_output()) then

--- a/assimilation_code/modules/assimilation/filter_mod.f90
+++ b/assimilation_code/modules/assimilation/filter_mod.f90
@@ -189,7 +189,7 @@ logical  :: output_timestamps        = .false.
 logical  :: trace_execution          = .false.
 logical  :: write_obs_every_cycle    = .false.  ! debug only
 logical  :: silence                  = .false.
-logical  :: distributed_state = .true. ! Default to do state complete forward operators.
+logical  :: distributed_state = .true. ! Default to do distributed forward operators.
 
 ! IO options
 !>@todo FIXME - how does this work for multiple domains?  ens1d1, ens2d1, ... ens1d2 or

--- a/assimilation_code/modules/assimilation/smoother_mod.f90
+++ b/assimilation_code/modules/assimilation/smoother_mod.f90
@@ -119,7 +119,7 @@ allow_missing = get_missing_ok_status()
 ! NOTE: Using ens_handle here (not lag_handle) so it doesn't die for 0 lag choice
 if(num_lags > 0) call adaptive_inflate_init(lag_inflate, 0, .false., .false., &
    .false. ,.true., 1.0_r8, 0.0_r8,       &
-   1.0_r8, 1.0_r8, 0.0_r8, 1.0_r8, ens_handle, allow_missing, "Lag")
+   1.0_r8, 1.0_r8, 0.0_r8, 1.0_r8, allow_missing, "Lag")
 
 end subroutine init_smoother
 

--- a/conf.py
+++ b/conf.py
@@ -21,7 +21,7 @@ copyright = '2022, University Corporation for Atmospheric Research'
 author = 'Data Assimilation Research Section'
 
 # The full version, including alpha/beta/rc tags
-release = '10.6.3'
+release = '10.6.4'
 master_doc = 'README'
 
 # -- General configuration ---------------------------------------------------

--- a/observations/obs_converters/NSIDC/HDF5_utilities_mod.f90
+++ b/observations/obs_converters/NSIDC/HDF5_utilities_mod.f90
@@ -14,7 +14,7 @@ use HDF5
 implicit none
 private
 
-public :: h5_open, H5_CRTDAT, H5_RDWT, &
+public :: h5_open, &
           h5_get_rank, &
           h5_get_dimensions, &
           h5_get_dset_dspace, &
@@ -66,7 +66,7 @@ end subroutine initialize_module
 function h5_open(filename, flag, context) result(file_id)
 
 character(len=*),           intent(in) :: filename
-integer(HID_T),             intent(in) :: flag
+integer,                    intent(in) :: flag
 character(len=*), optional, intent(in) :: context
 integer(HID_T)                         :: file_id
 
@@ -187,141 +187,6 @@ call error_handler(E_ERR, subr_name, string2, &
                    source, text2=string2, text3=filename)
 
 end subroutine h5_check
-
-
-subroutine H5_CRTDAT()
-
-! * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-!   Copyright by The HDF Group.                                               *
-!   Copyright by the Board of Trustees of the University of Illinois.         *
-!   All rights reserved.                                                      *
-!                                                                             *
-!   This routine is part of HDF5.  The full HDF5 copyright notice, including     *
-!   terms governing use, modification, and redistribution, is contained in    *
-!   the COPYING file, which can be found at the root of the source code       *
-!   distribution tree, or in https://support.hdfgroup.org/ftp/HDF5/releases.  *
-!   If you do not have access to either file, you may request a copy from     *
-!   help@hdfgroup.org.                                                        *
-! * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-!
-! The following example shows how to create an empty dataset.
-! It creates a file called 'dsetf.h5', defines the
-! dataset dataspace, creates a dataset which is a 4x6 integer array,
-! and then closes the dataspace, the dataset, and the file.
-!
-! This example is used in the HDF5 Tutorial.
-
-character(len=8), parameter :: filename = "dsetf.h5" ! File name
-character(len=4), parameter :: dsetname = "dset"     ! Dataset name
-
-integer(HID_T) :: file_id       ! File identifier
-integer(HID_T) :: dset_id       ! Dataset identifier
-integer(HID_T) :: dspace_id     ! Dataspace identifier
-
-integer(HSIZE_T), dimension(2) :: dims = (/4,6/) ! Dataset dimensions
-integer     ::   rank = 2                        ! Dataset rank
-
-integer     ::   error ! Error flag
-
-! Initialize FORTRAN interface.
-call h5open_f(error)
-
-! Create a new file using default properties.
-call h5fcreate_f(filename, H5F_ACC_TRUNC_F, file_id, error)
-
-! Create the dataspace.
-call h5screate_simple_f(rank, dims, dspace_id, error)
-
-! Create the dataset with default properties.
-call h5dcreate_f(file_id, dsetname, H5T_NATIVE_INTEGER, dspace_id, dset_id, error)
-
-! End access to the dataset and release resources used by it.
-call h5dclose_f(dset_id, error)
-
-! Terminate access to the data space.
-call h5sclose_f(dspace_id, error)
-
-! Close the file.
-call h5fclose_f(file_id, error)
-
-! Close FORTRAN interface.
-call h5close_f(error)
-
-end subroutine H5_CRTDAT
-
-
-subroutine H5_RDWT
-
-! * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-!   Copyright by The HDF Group.                                               *
-!   Copyright by the Board of Trustees of the University of Illinois.         *
-!   All rights reserved.                                                      *
-!                                                                             *
-!   This routine is part of HDF5.  The full HDF5 copyright notice, including     *
-!   terms governing use, modification, and redistribution, is contained in    *
-!   the COPYING file, which can be found at the root of the source code       *
-!   distribution tree, or in https://support.hdfgroup.org/ftp/HDF5/releases.  *
-!   If you do not have access to either file, you may request a copy from     *
-!   help@hdfgroup.org.                                                        *
-! * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-!
-! The following example shows how to write and read to/from an existing dataset.
-! It opens the file created in the previous example, obtains the dataset
-! identifier, writes the data to the dataset in the file,
-! then reads the dataset  to memory.
-!
-! This example is used in the HDF5 Tutorial.
-
-! Initialize the dset_data array.
-
-character(len=8), parameter :: filename = "dsetf.h5" ! File name
-character(len=4), parameter :: dsetname = "dset"     ! Dataset name
-
-integer(HID_T) :: file_id       ! File identifier
-integer(HID_T) :: dset_id       ! Dataset identifier
-
-integer :: error ! Error flag
-integer :: i, j
-
-integer, dimension(4,6) :: dset_data, data_out ! Data buffers
-integer(HSIZE_T), dimension(2) :: data_dims
-
-DO i = 1, 4
-   DO j = 1, 6
-      dset_data(i,j) = (i-1)*6 + j
-   END DO
-END DO
-
-
-! Initialize FORTRAN interface.
-call h5open_f(error)
-
-! Open an existing file.
-call h5fopen_f (filename, H5F_ACC_RDWR_F, file_id, error)
-
-! Open an existing dataset.
-call h5dopen_f(file_id, dsetname, dset_id, error)
-
-! Write the dataset.
-
-data_dims(1) = 4
-data_dims(2) = 6
-call h5dwrite_f(dset_id, H5T_NATIVE_INTEGER, dset_data, data_dims, error)
-
-! Read the dataset.
-call h5dread_f(dset_id, H5T_NATIVE_INTEGER, data_out, data_dims, error)
-
-! Close the dataset.
-call h5dclose_f(dset_id, error)
-
-! Close the file.
-call h5fclose_f(file_id, error)
-
-! Close FORTRAN interface.
-call h5close_f(error)
-
-end subroutine H5_RDWT
-
 
 end module HDF5_utilities_mod
 


### PR DESCRIPTION
## Description:
<!--- Describe your changes -->
This pull request fixes 3 refactoring issues:

* removed `state_ens_handle` from the `adaptive_inflate_init` arguments. `state_ens_handle` is unused in `adapative_inflate_init`, and (more seriously) not initialized until _after_ the call to `adaptive_inflate_init`.
* filter_mod  - fixed an untrue comment
* hd5f_utilities_mod removes some HFD5 tutorial code that made its way into the repo and fixes an i4 i8 mismatch that prevents compilation with modern compilers. 

### Fixes issue
<!--- link to github issue(s) -->
Fixes #340 #70 #68

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

### Tests
Please describe any tests you ran to verify your changes.
compiling everything in DART

## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [ ] No dataset needed
