### PR TITLE
Add DART input.nml to template in WRF Tutorial

### DIFF
--- a/models/wrf/tutorial/README.rst
+++ b/models/wrf/tutorial/README.rst
@@ -236,6 +236,7 @@ bash  ``export BASE_DIR=<path_to_your_working_directory>``
 
        cp $DART_DIR/models/wrf/tutorial/template/namelist.input.meso   $BASE_DIR/template/.
        cp $DART_DIR/models/wrf/tutorial/template/namelist.wps.template $BASE_DIR/template/.
+       cp $DART_DIR/models/wrf/tutorial/template/input.nml.template    $BASE_DIR/template/.
 
 3. You will also need the scripting to run a WRF/DART experiment. Copy
    the contents of ``$DART_DIR/models/wrf/shell_scripts`` to the


### PR DESCRIPTION

## Description:
<!--- Describe your changes -->
Simple 1 line documentation change that repairs broken link to WRF DART tutorial input.nml.template file.  Resolves problems during gen_retro_icbc.csh and init_ensemble_var.csh steps.


### Fixes issue
<!--- link to github issue(s) -->
Related to github issue #295 .   

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.


## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch


