### PR TITLE
fix: add sphinx_rtd_theme to extensions in conf.py

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,10 @@ individual files.
 
 The changes are now listed with the most recent at the top.
 
+**May 10 2023 :: Doc-fix. Tag v10.7.2**
+ 
+- conf.py changes for latest readthedocs. Fixes search and flyout menu.
+
 **May 8 2023 :: CLM-DART: CAM reanalysis site-level bias correction tool. Tag v10.7.1**
 
 - Initial version of bias correction for CAM reanalysis forcing for

--- a/conf.py
+++ b/conf.py
@@ -21,7 +21,7 @@ copyright = '2022, University Corporation for Atmospheric Research'
 author = 'Data Assimilation Research Section'
 
 # The full version, including alpha/beta/rc tags
-release = '10.7.1'
+release = '10.7.2'
 master_doc = 'README'
 
 # -- General configuration ---------------------------------------------------

--- a/conf.py
+++ b/conf.py
@@ -30,6 +30,7 @@ master_doc = 'README'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+     'sphinx_rtd_theme',
      'sphinx.ext.autodoc',
      'sphinx.ext.mathjax'
 ]


### PR DESCRIPTION
## Description:
<!--- Describe your changes -->
Add sphinx_rtd_theme so we use the latest version of the rtd theme.
This fixes the search function and flyout menu for readthedocs documentation
See issue #471 for discussion

### Fixes issue
<!--- link to github issue(s) -->
fixes #471 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Tests
Please describe any tests you ran to verify your changes.
Built the docs, checked the search and the flyout menu (version choice bottom left) worked:
https://docs.dart.ucar.edu/en/doc-search-fix/README.html

compare to https://docs.dart.ucar.edu/en/v10.7.1/README.html


## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [ ] No dataset needed
