### PR TITLE
Remove unused latlon_to_xyz_on_plane() subroutine from the mpas_atm model_mod

### DIFF
--- a/models/mpas_atm/model_mod.f90
+++ b/models/mpas_atm/model_mod.f90
@@ -7165,55 +7165,6 @@ end subroutine inside_triangle
 
 !------------------------------------------------------------
 
-subroutine latlon_to_xyz_on_plane(lat, lon, cellid, x, y, z)
-
-! FIXME: currently unused.  unless needed, could be removed.
-
-! Given a lat, lon in degrees, and the id of a cell in the
-! MPAS grid, return the cartesian x,y,z coordinate of that
-! location ON THE PLANE defined by the vertices of that cell.
-! This will be different from the x,y,z of the surface of the
-! sphere.  Uses the parametric form description from
-! http://en.wikipedia.org/wiki/Line-plane_intersection
-
-real(r8), intent(in)  :: lat, lon
-integer,  intent(in)  :: cellid
-real(r8), intent(out) :: x, y, z
-
-integer  :: nverts, i, vertexid
-real(r8) :: s(3)         ! location of point on surface
-real(r8) :: p(3,3)       ! first 3 vertices of cell, xyz
-real(r8) :: intp(3)      ! intersection point with plane
-
-call latlon_to_xyz(lat, lon, s(1), s(2), s(3))
-
-! get the first 3 vertices to define plane
-! intersect with sx,sy,sz to get answer
-
-! nedges and nverts is same
-nverts = nEdgesOnCell(cellid)
-if (nverts < 3) then
-   print *, 'nverts is < 3', nverts
-   stop
-endif
-
-! use first 3 verts to define plane
-do i=1, 3
-   vertexid = verticesOnCell(i, cellid)
-
-   p(1,i) = xVertex(vertexid)
-   p(2,i) = yVertex(vertexid)
-   p(3,i) = zVertex(vertexid)
-enddo
-
-x = intp(1)
-y = intp(2)
-z = intp(3)
-
-end subroutine latlon_to_xyz_on_plane
-
-!------------------------------------------------------------
-
 function vector_magnitude(a)
 
 ! Given a cartesian vector, compute the magnitude


### PR DESCRIPTION
## Description:
Removed the nonfunctioning latlon_to_xyz_on_plane() subroutine from DART/models/mpas_atm/model_mod.f90.
This also got rid of some compiler warnings when compiling mpas_atm on Derecho with cce.

### Fixes issue
Fixes #496 

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Documentation changes needed?
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

### Tests
Simply compiled mpas_atm to ensure there were no dependencies on the removed code.

## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [x] No dataset needed
