### PR TITLE
Fix test_interpolate_range format writing issue

### DIFF
--- a/models/model_mod_tools/test_interpolate_threed_sphere.f90
+++ b/models/model_mod_tools/test_interpolate_threed_sphere.f90
@@ -121,9 +121,9 @@ if ((interp_test_dlon < 0.0_r8) .or. (interp_test_dlat < 0.0_r8)) then
    if ( do_output() ) then
       write(*,'(A)')    'Skipping the rigorous interpolation test because one of'
       write(*,'(A)')    'interp_test_dlon,interp_test_dlat are < 0.0'
-      write(*,'(A,I2)') 'interp_test_dlon  = ',interp_test_dlon
-      write(*,'(A,I2)') 'interp_test_dlat  = ',interp_test_dlat
-      write(*,'(A,I2)') 'interp_test_dvert = ',interp_test_dvert
+      write(*,*) 'interp_test_dlon  = ',interp_test_dlon
+      write(*,*) 'interp_test_dlat  = ',interp_test_dlat
+      write(*,*) 'interp_test_dvert = ',interp_test_dvert
    endif
    return
 endif


### PR DESCRIPTION
## Description:
<!--- Describe your changes -->
Fixes a bug when running `model_mod_check` with a 3D sphere model, where test 5 would result in an error due to the formatting of three write statements in `test_interpolate_range_threed_sphere.f90`.

### Fixes issue
<!--- link to github issue(s) -->
Fixes #487 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

### Tests
Tested with panda_models branch on https://github.com/achauphan/DART/commit/8ed5a96599ca24815b5f55915556c9c50d654aae

## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [x] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [ ] No dataset needed
