### PR TITLE
fix misplaced comment about writing an obs_seq file

### DIFF
--- a/assimilation_code/modules/assimilation/filter_mod.f90
+++ b/assimilation_code/modules/assimilation/filter_mod.f90
@@ -1711,7 +1711,7 @@ real(r8)              :: rvalue(1)
 io_task = map_pe_to_task(obs_fwd_op_ens_handle, 0)
 my_task = my_task_id()
 
-! write the obs_seq.final file
+! create temp space for QC values
 if (my_task == io_task) then
    allocate(obs_temp(num_obs_in_set))
 else 


### PR DESCRIPTION
## Description:
<!--- Describe your changes -->
i was looking for something else and noticed a misleading comment in filter_mod


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation update (code comment)

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

### Tests
I compiled lorenz 96 and ran it.

## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [X] No dataset needed
