### PR TITLE
bug-fix: get_dist calculation for observations with VERTISUNDEF in WRF

### DIFF
--- a/models/wrf/model_mod.f90
+++ b/models/wrf/model_mod.f90
@@ -6403,6 +6403,13 @@ if (istatus1 == 0) then
       local_loc   = locs(t_ind)
       local_which = nint(query_location(local_loc))
 
+      if (present(dist)) then
+         if (local_which == VERTISUNDEF) then
+            dist(k) = get_dist(base_loc, local_loc, base_type, loc_qtys(t_ind))
+            cycle
+         endif
+      endif
+
       ! Convert local vertical coordinate to requested vertical coordinate if necessary.
       ! This should only be necessary for obs priors, as state location information already
       ! contains the correct vertical coordinate (filter_assim's call to get_state_meta_data).


### PR DESCRIPTION
## Description:
<!--- Describe your changes -->
Previously observations with VERTISUNDEF were given a large distance, because the vertical coordinate is missing: local_array(3) == missing_r8

https://github.com/NCAR/DART/blob/1b76f3afa5978469d6a119710bb638c1c077ae20/models/wrf/model_mod.f90#L6423-L6424

The location_mod::get_dist uses horizontal distance only if VERTISUNDEF for either location.

### Fixes issue
<!--- link to github issue(s) -->
Fixes #486 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

### Tests
Please describe any tests you ran to verify your changes.
Tested using an example case from Lukas K. 
#486 and https://github.com/NCAR/DART/compare/main...lukas-vertundef-wrf
Note lukas-vertundef-wrf has changes for wrf v4, this pull request only has the VERTISUNDEF bug fix.

## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [x] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [ ] No dataset needed
