### PR TITLE
Bug-fix: Mom6 time

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,21 @@ individual files.
 
 The changes are now listed with the most recent at the top.
 
+**July 27 2023 :: Bug-fixes for MOM6 and WRF. Tag v10.8.1**
+
+- bug-fixes:
+
+  - MOM6 read_model_time converts to dart time to match observation sequences.
+  - MOM6 salinity units converted to MSU during model_interpolate.
+  - WRF get_dist calculation fixed for observations with VERTISUNDEF.
+
+- doc-fixes:
+
+  - WOD and GTSPP converter documentation notes about salinity units.
+  - MOM6 documentation for setting the Gregorian calendar in CESM.
+  - comment fix in filter_mod.f90
+
+
 **June 27 2023 :: CAM-DART observation preprocessor. Tag v10.8.0**
 
 - Tool to remove observations above a given CAM level from an obs sequence file

--- a/conf.py
+++ b/conf.py
@@ -21,7 +21,7 @@ copyright = '2022, University Corporation for Atmospheric Research'
 author = 'Data Assimilation Research Section'
 
 # The full version, including alpha/beta/rc tags
-release = '10.8.0'
+release = '10.8.1'
 master_doc = 'README'
 
 # -- General configuration ---------------------------------------------------

--- a/models/MOM6/model_mod.f90
+++ b/models/MOM6/model_mod.f90
@@ -945,14 +945,21 @@ type(time_type) :: read_model_time
 integer :: ncid
 character(len=*), parameter :: routine = 'read_model_time'
 real(r8) :: days
+type(time_type) :: mom6_time
+integer :: dart_base_date_in_days, dart_days
 
+dart_base_date_in_days = 584388 ! 1601 1 1 0 0
 ncid = nc_open_file_readonly(filename, routine)
 
 call nc_get_variable(ncid, 'Time', days, routine)
 
 call nc_close_file(ncid, routine)
 
-read_model_time = set_time(0,int(days))
+! MOM6 counts days from year 1
+! DART counts days from 1601 
+dart_days = int(days) - dart_base_date_in_days
+
+read_model_time = set_time(0,dart_days)
 
 end function read_model_time
 

--- a/models/MOM6/readme.rst
+++ b/models/MOM6/readme.rst
@@ -9,6 +9,48 @@ Instructions for using MOM6 in CESM are available on the `MOM_interface GitHub W
 
 This DART-MOM6 interface was developed for `MOM6 <https://github.com/NCAR/MOM6>`_ within the CESM framework.
 
+MOM6 time
+---------
+
+The default in CESM is to run with no leap years.
+To assimilate real observations, we need to switch to the Gregorian 
+calendar to account for leap years.
+
+.. code-block:: text
+
+    ./xmlchange CALENDAR=GREGORIAN
+
+To illustrate what happens if you do not set CALENDAR=GREGORIAN, here is
+an example where the RUN_STARTDATE is set to 2015-02-01 and MOM6 is run for 10 days.
+
+.. code-block:: text
+
+    ./xmlchange RUN_STARTDATE=2015-02-01
+
+The MOM6 restart file has the following meta data, where Time is days from year 1.
+
+.. code-block:: text
+
+    double Time(Time) ;
+                    Time:long_name = "Time" ;
+                    Time:units = "days" ;
+                    Time:axis = "T" ;
+    ...
+    // global attributes:
+    		:filename = "./c.T62_g16.ens3.mom6.r.2015-02-11-00000._0001.nc" ;
+    data:
+    
+     Time = 735151 ;
+    }
+
+
+The absence of leap years gives you inconsistent time information when comparing 
+to observation times in YYYY-MM-DD:
+
+- Restart filename has the time 2015-02-11-00000.
+- The Time variable is Time = 735151 days, which is 2013/10/11
+
+
 MOM6 checksum of restart files
 ------------------------------
 


### PR DESCRIPTION
## Description:
<!--- Describe your changes -->
This pull request fixes read_model_time MOM6:

* MOM6 time is in days from year 1.  DART time is from 1601.  This pull request converts MOM6 time to DART time in read_model_time. 

* Documentation updated to show how to turn on leap years for CESM (the default is no leap year).  Added an example in the docs to illustrate Time in days vs. YYYY-MM-DD when you do not have leap years. 

* The write_model_time is **not** converted back to MOM6 time. See #494 for discussion on this.  DART created files have dart time to match the observation times. 


### Fixes issue
<!--- link to github issue(s) -->
fixes #494 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.

### Tests
Please describe any tests you ran to verify your changes.

## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [ ] No dataset needed
