### PR TITLE
fix: salinity units for observation converters WOD and GTSPP an MOM6

### DIFF
--- a/models/MOM6/model_mod.f90
+++ b/models/MOM6/model_mod.f90
@@ -49,7 +49,7 @@ use distributed_state_mod, only : get_state, get_state_array
 
 use obs_kind_mod, only : get_index_for_quantity, QTY_U_CURRENT_COMPONENT, &
                          QTY_V_CURRENT_COMPONENT, QTY_LAYER_THICKNESS, &
-                         QTY_DRY_LAND
+                         QTY_DRY_LAND, QTY_SALINITY
 
 use ensemble_manager_mod, only : ensemble_type
 
@@ -382,6 +382,11 @@ enddo
 ! Interpolate between levels
 ! expected_obs = bot_val + lev_fract * (top_val - bot_val)
 expected_obs = expected(:,1) + lev_fract(:) * (expected(:,2) - expected(:,1))
+
+if (qty == QTY_SALINITY) then  ! convert from PSU (model) to MSU (obersvation)
+   expected_obs = expected_obs/1000.0_r8
+endif
+
 
 end subroutine model_interpolate
 

--- a/observations/obs_converters/GTSPP/GTSPP.rst
+++ b/observations/obs_converters/GTSPP/GTSPP.rst
@@ -26,6 +26,13 @@ information (not quality control, but observation instrument error values). Ther
 information encoded in these files, but so far we don't have the key. The quality control values are read and only those
 with a QC of 1 are retained.
 
+.. Note::  
+
+   The GTSPP data is in PSU, the dart observation converter ``gtspp_to_obs`` converts the observations to MSU.
+ 
+   | PSU = g/kg
+   | MSU = PSU/1000 = kg/kg
+
 Programs
 --------
 

--- a/observations/obs_converters/WOD/WOD.rst
+++ b/observations/obs_converters/WOD/WOD.rst
@@ -40,7 +40,7 @@ format for the World Ocean Database 2013 (WOD13) and the World Ocean Database
 
 .. Warning::  
 
-   The WOD data is in PSU, the dart observation converter ``wod_to_obs`` converts the observation to MSU.
+   The WOD data is in PSU, the dart observation converter ``wod_to_obs`` converts the observations to MSU.
  
    | PSU = g/kg
    | MSU = PSU/1000 = kg/kg

--- a/observations/obs_converters/WOD/WOD.rst
+++ b/observations/obs_converters/WOD/WOD.rst
@@ -38,6 +38,15 @@ NCAR staff have prepared datasets already converted to DART's obs_seq file
 format for the World Ocean Database 2013 (WOD13) and the World Ocean Database
 2009 (WOD09).
 
+.. Warning::  
+
+   The WOD data is in PSU, the dart observation converter ``wod_to_obs`` converts the observation to MSU.
+ 
+   | PSU = g/kg
+   | MSU = PSU/1000 = kg/kg
+   
+   The WOD observation sequence files availiable from NCAR's RDA are in MSU.
+
 WOD13
 ~~~~~
 


### PR DESCRIPTION
## Description:
<!--- Describe your changes -->
Added notes/warning for the unit change by the observation converters. 
WOD, GTSPP

MOM6 convert salinity to MSU in model_interpolate

### Fixes issue
<!--- link to github issue(s) -->
Fixes #509 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.

### Tests
Please describe any tests you ran to verify your changes.
Documentation build.

## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [x] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [ ] No dataset needed
