### PR TITLE
make clear obs_window_seconds and obs_window_days are unsupported

### DIFF
--- a/assimilation_code/modules/assimilation/filter_mod.f90
+++ b/assimilation_code/modules/assimilation/filter_mod.f90
@@ -170,7 +170,9 @@ integer  :: first_obs_days      = -1
 integer  :: first_obs_seconds   = -1
 integer  :: last_obs_days       = -1
 integer  :: last_obs_seconds    = -1
-! Assimilation window; defaults to model timestep size.
+! Assimilation window; default is model timestep size. 
+! Changing these is currently unsupported/not implemented. 
+! Reserved for future use.
 integer  :: obs_window_days     = -1
 integer  :: obs_window_seconds  = -1
 ! Control diagnostic output for state variables
@@ -1507,7 +1509,7 @@ integer,         intent(in)  :: days, seconds
 type(time_type), intent(out) :: dart_time
 logical,         intent(out) :: read_time_from_file
 
-if(days >= 0) then
+if(days >= 0 .or. seconds >= 0) then
    dart_time = set_time(seconds, days)
    read_time_from_file = .false.
 else
@@ -1524,7 +1526,14 @@ subroutine filter_set_window_time(dart_time)
 type(time_type), intent(out) :: dart_time
 
 
-if(obs_window_days >= 0) then
+if(obs_window_days >= 0 .or. obs_window_seconds >= 0) then
+   write(msgstring, *) 'obs_window_days and obs_window_seconds are currently unsupported and will be ignored.'
+   call error_handler(E_MSG, 'filter_set_window_time: ', msgstring)
+
+   ! we still need to set the output to something. in the current code
+   ! this time is passed into move_ahead() where it is then ignored.  
+   ! if it is ever supported there the two lines above should be removed and
+   ! this next line is the correct code to use.
    dart_time = set_time(obs_window_seconds, obs_window_days)
 else
    dart_time = set_time(0, 0)

--- a/assimilation_code/modules/assimilation/filter_mod.rst
+++ b/assimilation_code/modules/assimilation/filter_mod.rst
@@ -263,11 +263,11 @@ prior inflation and the second controls the posterior inflation.
 |                              |                     | If non-negative, ignore all observations  |
 |                              |                     | after this time.                          |
 +------------------------------+---------------------+-------------------------------------------+
-| obs_window_days              | integer             | Assimilation window days;                 |
-|                              |                     | defaults to model timestep size.          |
+| obs_window_days              | integer             | Currently unsupported.  Leave as -1.      |
+|                              |                     | Reserved for future use.                  |
 +------------------------------+---------------------+-------------------------------------------+
-| obs_window_seconds           | integer             | Assimilation window seconds;              |
-|                              |                     | defaults to model timestep size.          |
+| obs_window_seconds           | integer             | Currently unsupported.  Leave as -1.      |
+|                              |                     | Reserved for future use.                  |
 +------------------------------+---------------------+-------------------------------------------+
 | All variables named inf_* are arrays of length 2. The first element controls the prior,        |
 | the second element controls the posterior inflation. See :doc:`../../programs/filter/filter`   |

--- a/assimilation_code/programs/perfect_model_obs/perfect_model_obs.f90
+++ b/assimilation_code/programs/perfect_model_obs/perfect_model_obs.f90
@@ -90,6 +90,9 @@ integer  :: first_obs_days     = -1
 integer  :: first_obs_seconds  = -1
 integer  :: last_obs_days      = -1
 integer  :: last_obs_seconds   = -1
+! Assimilation window; default is model timestep size.
+! Changing these is currently unsupported/not implemented.
+! Reserved for future use.    
 integer  :: obs_window_days    = -1
 integer  :: obs_window_seconds = -1
 logical  :: output_forward_op_errors = .false.
@@ -295,6 +298,11 @@ call set_io_copy_flag( file_info_output, 1, 1, WRITE_COPY, num_output_ens=1)
 
 ! Set a time type for initial time if namelist inputs are not negative
 call filter_set_initial_time(init_time_days, init_time_seconds, time1, read_time_from_file)
+! Catch if someone is trying to use an unsupported option.
+if (obs_window_days >= 0 .or. obs_window_seconds >= 0) then
+   write(msgstring, *) 'obs_window_days and obs_window_seconds are currently unsupported and will be ignored.'
+   call error_handler(E_MSG, 'perfect_main', msgstring)
+endif
 
 if (read_input_state_from_file) then
 

--- a/assimilation_code/programs/perfect_model_obs/perfect_model_obs.rst
+++ b/assimilation_code/programs/perfect_model_obs/perfect_model_obs.rst
@@ -121,13 +121,11 @@ namelist.
    |                                       |                                       | non-negative, ignore any observations |
    |                                       |                                       | after this time.                      |
    +---------------------------------------+---------------------------------------+---------------------------------------+
-   | obs_window_days                       | integer                               | If negative, don't use. If            |
-   |                                       |                                       | non-negative, reserved for future     |
-   |                                       |                                       | use.                                  |
+   | obs_window_days                       | integer                               | Currently unsupported.  Leave as -1.  |
+   |                                       |                                       | Reserved for future use.              |
    +---------------------------------------+---------------------------------------+---------------------------------------+
-   | obs_window_seconds                    | integer                               | If negative, don't use. If            |
-   |                                       |                                       | non-negative, reserved for future     |
-   |                                       |                                       | use.                                  |
+   | obs_window_seconds                    | integer                               | Currently unsupported.  Leave as -1.  |
+   |                                       |                                       | Reserved for future use.              |
    +---------------------------------------+---------------------------------------+---------------------------------------+
    | trace_execution                       | logical                               | True means output very detailed       |
    |                                       |                                       | messages about what routines are      |


### PR DESCRIPTION
## Description
both filter and perfect_model_obs have obs_window_days and obs_window_seconds in their namelists.  these are for future use and are currently unsupported.  update the docs to be more clear about this and update the code to print out a warning message if they are changed to be >= 0.

also check both the days and seconds values for obs_window_xxx and also init_time_xxx.  if either are >= 0, call set_time(). that will catch and print a fatal error if one is set and the other is left at -1.  the old code only tested days, so if someone set seconds >= 0 but left days negative the init time would have been set to 0, 0 and the namelist values wouldn't have been used without any message.

### Fixes issue
#520

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.

### Tests
I ran Lorenz 96 pmo and filter with various combinations of values in the namelist for both init_time_xxx and obs_window_xxx and it gave me the results i expected.

## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [x] No dataset needed
