### PR TITLE
Added get_channel to obs_def_rttov13_mod.f90

### DIFF
--- a/observations/forward_operators/obs_def_rttov13_mod.f90
+++ b/observations/forward_operators/obs_def_rttov13_mod.f90
@@ -397,7 +397,8 @@ public ::         set_visir_metadata, &
                 write_rttov_metadata, &
           interactive_rttov_metadata, &
                get_expected_radiance, &
-            get_rttov_option_logical
+            get_rttov_option_logical, &
+                         get_channel
 
 ! The rttov_test.f90 program uses these, but no one else should.
 


### PR DESCRIPTION
## Description:
radiance_obs_seq_to_netcdf with rttov13 failed to compile with error #6580: Name in only-list does not exist or is not accessible [GET_CHANNEL]. Fix: Added public get_channel to obs_def_rttov13_mod.f90 to compile WRF successfully.

### Fixes issue
fixes #532 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

### Tests
Add radiance_obs_seq_to_netcdf to ./quickbuild.sh. Then, run ./quickbuild.sh radiance_obs_seq_to_netcdf on DART/wrf/work. 

## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [X] No dataset needed
