### PR TITLE
bug fix: remove cloud_overlap integer from list of logicals to query 

### DIFF
--- a/observations/forward_operators/obs_def_rttov13_mod.f90
+++ b/observations/forward_operators/obs_def_rttov13_mod.f90
@@ -4238,8 +4238,6 @@ function get_rttov_option_logical(field_name) result(p)
          p = USER_CLD_OPT_PARAM
       case('GRID_BOX_AVG_CLOUD')
          p = GRID_BOX_AVG_CLOUD
-      case('CLOUD_OVERLAP')
-         p = cloud_overlap
       case('ADDPC')
          p = ADDPC
       case('ADDRADREC')


### PR DESCRIPTION
## Description:
<!--- Describe your changes -->
obs_def_rttov13_mod.f90 was failing to compile on Derecho using CCE because "Assignment of a INTEGER expression to a LOGICAL variable is not allowed"
This pull request removes cloud_overlap (integer) from the function: `get_rttov_option_logical`

Also includes pull #540 

### Fixes issue
<!--- link to github issue(s) -->
Fixes #537, #532 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

### Tests
Compile with cce (Cray Fortran 15.0.01) on Derecho.

## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [x] No dataset needed

Edit:
/glade/derecho/scratch/hkershaw/DART/Bugs/issue_537/build_templates/mkmf.template for building with rttov13_cray on Derecho.
