### PR TITLE
Updating mpi_utilities_mod to use the mpi_f08 module

### DIFF
--- a/assimilation_code/modules/utilities/mpi_utilities_mod.f90
+++ b/assimilation_code/modules/utilities/mpi_utilities_mod.f90
@@ -1975,7 +1975,7 @@ integer,  intent(in)  :: owner    ! task in the window that owns the memory
 type(MPI_Win),  intent(in)  :: window   ! window object
 integer,  intent(in)  :: mindex   ! index in the tasks memory
 integer,  intent(in)  :: num_rows ! number of rows in the window
-real(r8), intent(out) :: x(:)     ! result
+real(r8), intent(out) :: x(num_rows)     ! result
 
 integer(KIND=MPI_ADDRESS_KIND) :: target_disp
 integer :: errcode

--- a/assimilation_code/modules/utilities/mpi_utilities_mod.f90
+++ b/assimilation_code/modules/utilities/mpi_utilities_mod.f90
@@ -50,7 +50,7 @@ use time_manager_mod, only : time_type, get_time, set_time
 ! For more help on compiling a module which uses MPI see the 
 ! $DART/developer_tests/mpi_utilities/tests/README
 
-use mpi
+use mpi_f08
 
 
 ! We build on case-insensitive systems so we cannot reliably
@@ -127,9 +127,9 @@ end interface
 
 integer :: myrank        = -1  ! my mpi number
 integer :: total_tasks   = -1  ! total mpi tasks/procs
-integer :: my_local_comm =  0  ! duplicate communicator private to this file
-integer :: datasize      =  0  ! which MPI type corresponds to our r8 definition
-integer :: longinttype   =  0  ! create an MPI type corresponding to our i8 definition
+type(MPI_Comm) :: my_local_comm  ! duplicate communicator private to this file
+type(MPI_Datatype) :: datasize  ! which MPI type corresponds to our r8 definition
+type(MPI_Datatype) :: longinttype  ! create an MPI type corresponding to our i8 definition
 
 
 
@@ -222,7 +222,7 @@ subroutine initialize_mpi_utilities(progname, alternatename, communicator)
 
 character(len=*), intent(in), optional :: progname
 character(len=*), intent(in), optional :: alternatename
-integer,          intent(in), optional :: communicator
+type(MPI_Comm),   intent(in), optional :: communicator
 
 integer :: errcode, iunit
 logical :: already
@@ -678,7 +678,7 @@ subroutine receive_from(src_id, destarray, time, label)
 
 integer :: tag, errcode
 integer :: itime(2)
-integer :: status(MPI_STATUS_SIZE)
+type(MPI_Status) :: status
 integer(i8) :: itemcount, offset, nextsize
 real(r8), allocatable :: tmpdata(:)
 
@@ -1759,7 +1759,7 @@ function shell_execute(execute_string, serialize)
 
 logical :: all_at_once
 integer :: errcode, dummy(1)
-integer :: status(MPI_STATUS_SIZE)
+type(MPI_Status) :: status
 
 if (verbose) async2_verbose = .true.
 
@@ -1932,9 +1932,10 @@ end function read_mpi_timer
 !> return our communicator
 
 function get_dart_mpi_comm()
- integer :: get_dart_mpi_comm
 
- get_dart_mpi_comm = my_local_comm
+type(MPI_Comm) :: get_dart_mpi_comm
+
+get_dart_mpi_comm = my_local_comm
 
 end function get_dart_mpi_comm
 
@@ -1945,7 +1946,7 @@ end function get_dart_mpi_comm
 subroutine get_from_mean(owner, window, mindex, x)
 
 integer,  intent(in)  :: owner  ! task in the window that owns the memory
-integer,  intent(in)  :: window ! window object
+type(MPI_Win), intent(in)  :: window ! window object
 integer,  intent(in)  :: mindex ! index in the tasks memory
 real(r8), intent(out) :: x      ! result
 
@@ -1971,7 +1972,7 @@ end subroutine get_from_mean
 subroutine get_from_fwd(owner, window, mindex, num_rows, x)
 
 integer,  intent(in)  :: owner    ! task in the window that owns the memory
-integer,  intent(in)  :: window   ! window object
+type(MPI_Win),  intent(in)  :: window   ! window object
 integer,  intent(in)  :: mindex   ! index in the tasks memory
 integer,  intent(in)  :: num_rows ! number of rows in the window
 real(r8), intent(out) :: x(:)     ! result

--- a/assimilation_code/modules/utilities/no_cray_win_mod.f90
+++ b/assimilation_code/modules/utilities/no_cray_win_mod.f90
@@ -15,7 +15,7 @@ use ensemble_manager_mod, only : ensemble_type, map_pe_to_task, get_var_owner_in
                                  set_num_extra_copies, all_copies_to_all_vars, &
                                  all_vars_to_all_copies
 
-use mpi
+use mpi_f08
 
 implicit none
 
@@ -25,8 +25,8 @@ public :: create_mean_window, create_state_window, free_mean_window, &
           mean_ens_handle, NO_WINDOW, MEAN_WINDOW, STATE_WINDOW
 
 ! mpi window handles
-integer :: state_win   !< window for the forward operator
-integer :: mean_win    !< window for the mean
+type(MPI_Win) :: state_win   !< window for the forward operator
+type(MPI_Win) :: mean_win    !< window for the mean
 integer :: current_win !< keep track of current window, start out assuming an invalid window
 
 ! parameters for keeping track of which window is open

--- a/assimilation_code/modules/utilities/null_mpi_utilities_mod.f90
+++ b/assimilation_code/modules/utilities/null_mpi_utilities_mod.f90
@@ -640,7 +640,7 @@ integer,  intent(in)  :: owner    ! task in the window that owns the memory
 integer,  intent(in)  :: window   ! window object
 integer,  intent(in)  :: mindex   ! index in the tasks memory
 integer,  intent(in)  :: num_rows ! number of rows in the window
-real(r8), intent(out) :: x(:)     ! result
+real(r8), intent(out) :: x(num_rows)     ! result
 
 call error_handler(E_ERR,'get_from_fwd', 'cannot be used in serial mode', source)
 


### PR DESCRIPTION
## Description:
<!--- Describe your changes -->
Errors from mpi_utilities_mod are produced when cray-mpich and gfortran use f77 bindings with `use mpi`

The f08 mpi module `use mpi_f08` follows the fortran standard.
mpi_utilites_mod has been updated to use the mpi_f08 module with mpi_f08 bindings. 

This fixes the issues with mpich and gfortran 10+

The following items were mentioned in the corresponding issues, but will not be addressed in the PR and will be a part of a larger refactor of our MPI code:
- Updating mpi_utilities_mod to MPI3 - MPI_INTEGER_KIND, MPI_COUNT_KIND 
- Removal of the cray pointer window
- maybe using fortran intrinsics for executing other programs so we don't have to use fixsystem


### Fixes issue
Fixes #261 #551 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

### Tests
Ran quickbuild.sh using cray-mpich and the gfortran compiler with full debugging flags on Derecho; executed filter
Repeated this process for the Intel and cce compilers to ensure these changes didn't affect the other compilers' ability to compile and run.

## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [x] No dataset needed
