### PR TITLE
Fixes for remaining documentation warnings in #546

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -293,6 +293,7 @@ References
    observations/obs_converters/AIRS/convert_airs_L2
    observations/obs_converters/AIRS/convert_amsu_L1
    observations/obs_converters/AVISO/AVISO
+   observations/obs_converters/Ameriflux/fluxnetfull_to_obs
    observations/obs_converters/Ameriflux/level4_to_obs
    observations/obs_converters/CHAMP/work/README
    observations/obs_converters/cice/cice_to_obs
@@ -414,6 +415,7 @@ References
    models/rose/readme
    models/simple_advection/readme
    models/sqg/readme
+   models/template/new_model
    models/tiegcm/readme
    models/wrf_hydro/readme
    models/wrf/readme

--- a/models/lorenz_96_tracer_advection/readme.rst
+++ b/models/lorenz_96_tracer_advection/readme.rst
@@ -63,7 +63,7 @@ one dimensional array. The tracer particle in the figure lands on a predefined g
 point at t\ :sup:`n+1`. The trajectory of this tracer particle is then integrated 
 backwards by one time step to time t\ :sup:`n`, often landing between grid points. 
 Then, due to advection without diffusion, the concentration of tracer at time
- t\ :sup:`n+1` is simply the concentration of tracer at time t\ :sup:`n`, which 
+t\ :sup:`n+1` is simply the concentration of tracer at time t\ :sup:`n`, which 
 can be determined by interpolating concentrations of the surrounding grids [3]_.
 
 Once the coupled Lorenz 96 and semi-Lagrangian is run with a source of strength

--- a/observations/obs_converters/Ameriflux/level4_to_obs.rst
+++ b/observations/obs_converters/Ameriflux/level4_to_obs.rst
@@ -10,7 +10,7 @@ AmeriFlux level 4 data to DART observation sequence converter
 | This routine was designed to convert the flux tower Level 4 data from the `AmeriFlux <http://ameriflux.lbl.gov>`__
   network of observations from micrometeorological tower sites. The download link and flux data format for this code
   *has been discontinued* (e.g. ``USBar2004_L4_h.txt``).  Thus if you are using flux obs converters for the first time
-  *PLEASE USE* the updated ``Fluxnetfull_to_obs.f90`` converter and follow the documentation there :doc:`./Fluxnetfull_to_obs`
+  *PLEASE USE* the updated ``Fluxnetfull_to_obs.f90`` converter and follow the documentation there :doc:`./fluxnetfull_to_obs`
   We have kept this code available if you still use the older Ameriflux data format.  Also this code uses a general approach
   to calculating sensible, latent and net ecosystem exchange uncertainty, that may be helpful. 
 | The AmeriFlux Level 4 data products are provided in the local time of the flux tower location. DART observation sequence


### PR DESCRIPTION
## Description:
<!--- Describe your changes -->
This pr fixes the documentation warnings in:
index.rst -> added new_model template and fluxnetfull_to_obs to toctree
models/lorenz_96_tracer_advection/readme.rst -> removed unnecessary indentation in line 66
observations/obs_converters/Ameriflux/level4_to_obs.rst -> uncapitalized "f" for fluxnetfull_to_obs.rst

### Fixes issue
This pr resolves the remaining documentation warnings in Issue #546.
fixes #546 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

### Tests
Please describe any tests you ran to verify your changes.
After these changes, I ran "make clean" then "make html" to verify that no warnings were left.

## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [ ] No dataset needed
