### PR TITLE
fix print of number of obs converted, and make input.nml defaults better

### DIFF
--- a/observations/obs_converters/AIRS/airs_obs_mod.f90
+++ b/observations/obs_converters/AIRS/airs_obs_mod.f90
@@ -316,7 +316,7 @@ rowloop:  do irow=1,AIRS_RET_GEOTRACK
 enddo rowloop
 
 ! Print a little summary
-write(msgstring,*) 'obs used = ', obs_num
+write(msgstring,*) 'obs used = ', obs_num - 1
 call error_handler(E_MSG, ' ', msgstring)
 
 call print_obs_seq_summary(seq)

--- a/observations/obs_converters/AIRS/work/input.nml
+++ b/observations/obs_converters/AIRS/work/input.nml
@@ -18,17 +18,17 @@
 !   l2_files = '../data/AIRS.2017.01.01.110.L2.RetStd_IR.v6.0.31.1.G19058124823.hdf'
 
 &convert_airs_L2_nml
-   l2_files           = ''
-   l2_file_list       = 'l2_files_to_process'
+   l2_files           = 'AIRS.2017.01.01.110.L2.RetStd_IR.v6.0.31.1.G19058124823.hdf'
+   l2_file_list       = ''
    outputfile         = 'obs_seq.test'
    min_MMR_threshold  = 1.0e-30
    top_pressure_level = 0.0001
-   along_track_thin   = 1
-   cross_track_thin   = 1
+   along_track_thin   = 0
+   cross_track_thin   = 0
    lon1               =   0.0
    lon2               = 360.0
-   lat1               = -60.0
-   lat2               =  60.0
+   lat1               = -90.0
+   lat2               =  90.0
   /
 
 


### PR DESCRIPTION
the convert_airs_L2 converter was printing 1 more obs converted than was actually done.

also, the settings for the convert_airs_L2 namelist thinned out all the obs.  change the defaults to include all possible obs, including all latitudes, and give an example filename for input instead of a list name.  the input file isn't in our repo, but it might help a user see what kind of filename they're looking for.

## Description:
fix printout of number of obs converted to be right.
also change namelist defaults to not thin out all obs 

### Fixes issue
fixes #596 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

### Tests
i built and ran this with my copy of the updated HDF_EOS libraries and it printed out the correct number of obs.  it also didn't thin them all out.

## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [x] Dataset needed for testing available upon request - there is an AIRS hdf file in my home dir on cheyenne/derecho
- [ ] Dataset download instructions included
- [ ] No dataset needed
