### PR TITLE
remove register for dart link because this no longer exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![GitHub forks](https://img.shields.io/github/forks/NCAR/DART?style=social)](https://github.com/NCAR/DART/network)
 [![GitHub release](https://img.shields.io/github/v/release/NCAR/DART)](https://github.com/NCAR/DART/releases/latest)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Documentation Status](https://readthedocs.org/projects/dart-documentation/badge/?version=latest)](https://dart-documentation.readthedocs.io/en/latest/?badge=latest)
 
 ![DARTlogo](guide/images/Dartboard7.png)
@@ -22,8 +23,6 @@ DART is available through GitHub. To download the latest version of DART:
 ```
 git clone https://github.com/NCAR/DART.git
 ```
-
-To register for DART and view the terms of use, click on [register for DART](https://www2.cisl.ucar.edu/software/dart/download).
 
 #### Citing DART
 

--- a/models/wrf/tutorial/README.rst
+++ b/models/wrf/tutorial/README.rst
@@ -1358,8 +1358,6 @@ More Resources
 
 -  `Check or Submit DART Issues <https://github.com/NCAR/DART/issues>`__
 -  `DAReS website <ttp://dart.ucar.edu>`__
--  `Register for
-   DART <https://www2.cisl.ucar.edu/software/dart/download>`__
 -  `Preparing
    MATLAB <https://dart.ucar.edu/pages/Getting_Started.html#matlab>`__
    to use with DART.


### PR DESCRIPTION
remove register for dart link because this no longer exists:
* README.md
* models/wrf/tutorial/README.rst

Added Apache license badge to README.md

## Description:
<!--- Describe your changes -->
Please provide a summary of the change and include any relevant motivation and context. 

### Fixes issue
<!--- link to github issue(s) -->
Fixes #616 if you ignore the header in every file. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.

### Tests
Built docs with sphinx locally. 
Previewed README.md with macdown.

## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [ ] No dataset needed
