### PR TITLE
fix: format statement in assert_mod

### DIFF
--- a/assimilation_code/modules/utilities/assert_mod.f90
+++ b/assimilation_code/modules/utilities/assert_mod.f90
@@ -6,6 +6,8 @@
 !> Aim: collection of assertions for use in test code
 module assert_mod
 
+use types_mod, only : r8, r4, i8
+
 implicit none
 
 public
@@ -37,7 +39,7 @@ contains
 !-------------------------------
 subroutine assert_equal_real(a, b, message)
 
-real, intent(in) :: a, b
+real(r4), intent(in) :: a, b
 character(len=*), intent(in) :: message
 
 if (a /= b) print*, 'FAIL: ', trim(message),' assertion ', a, '==', b, 'failed'
@@ -67,7 +69,7 @@ end subroutine assert_equal_int
 !-------------------------------
 subroutine assert_equal_int8(a, b, message)
 
-integer*8,        intent(in) :: a, b
+integer(i8),        intent(in) :: a, b
 character(len=*), intent(in) :: message
 
 if (a /= b) print*, 'FAIL: ',  trim(message),' assertion ', a, '==', b, 'failed'
@@ -142,7 +144,7 @@ if (any(a .neqv. b)) then
 
    if (size(a) < 100) then
       do i = 1,size(a)
-         write(*,'(''       element('',i3,'') '',L,'' ?==? '',L)')i, a(i), b(i)
+         write(*,'(''       element('',i3,'') '',L1,'' ?==? '',L1)')i, a(i), b(i)
       enddo
    else
       print*, 'arrays too long to concisely specify where/how failed.'


### PR DESCRIPTION
## Description:
<!--- Describe your changes -->
Fix for format statement in assert_mod. The goal of putting in this seemingly inconsequential change in is so the NAG compiler can be used to build dart, and not error out on this. 

The other NAG build error is fixed in #588.

### Fixes issue
<!--- link to github issue(s) -->
fixes nag compiler (item 2) #615

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

### Tests
Please describe any tests you ran to verify your changes.


```
program test_assert

use assert_mod, only : assert_equal_logical_array

implicit none

logical :: a(3), b(3)

a(:) = .true.
b(:) = .false.

call assert_equal_logical_array(a,b, 'beans on toast')

end program test_assert
```

add test_assert to serial_programs in quickdbuild.sh 

```
./quickdbuild.sh test_assert
./test_assert 
```

## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [ ] No dataset needed
