### PR TITLE
Add integer_to_string, pad_left, zero_fill functions to utilities_mod

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,10 @@ individual files.
 
 The changes are now listed with the most recent at the top.
 
+**February 29 2024 :: Add helper functions to utilities_mod. Tag v11.0.4**
+
+- Adds three functions to ``utilities_mod``: ``zero_fill``, ``pad_left`` and ``integer_to_string``.
+
 **February 13 2024 :: Fortran Standards. Tag v11.0.3**
 
 - Replace f2kcli with Fortran intrinsics for command line arguments.

--- a/assimilation_code/modules/utilities/utilities_mod.f90
+++ b/assimilation_code/modules/utilities/utilities_mod.f90
@@ -61,11 +61,14 @@ public :: get_unit, &
           scalar, &
           string_to_real, &
           string_to_integer, &
+          integer_to_string, &
           string_to_logical, &
           find_enclosing_indices, &
           find_first_occurrence, &
           array_dump, &
           dump_unit_attributes, &
+          zero_fill, &
+          pad_left, &
           ! lowest level routines follow.
           ! these need to be cautious about logging, error handlers, etc
           initialize_utilities, &
@@ -2054,6 +2057,21 @@ if (io /= 0) string_to_integer = MISSING_I
 
 end function string_to_integer
 
+!-----------------------------------------------------------------------
+!>
+
+function integer_to_string(input_integer)
+
+integer, intent(in) :: input_integer
+character(len=32) :: integer_to_string
+integer :: io
+
+! if the integer converts - great, if not, it's the
+! string equivalent of MISSING_I
+write(integer_to_string,'(I0)',iostat=io) input_integer
+if (io /= 0)  integer_to_string = '-888888'
+
+end function integer_to_string
 
 !-----------------------------------------------------------------------
 !>  if matching true or false, uppercase the string so any
@@ -2100,7 +2118,40 @@ end select
 
 end function string_to_logical
 
+!-----------------------------------------------------------------------
+!>
 
+function zero_fill(inputstring, desired_length)
+
+character(len=*), intent(in) :: inputstring
+integer, intent(in) :: desired_length
+character(len=max(len_trim(inputstring), desired_length)) :: zero_fill
+
+zero_fill = pad_left(inputstring, desired_length, '0')  
+
+end function zero_fill
+
+!-----------------------------------------------------------------------
+!>
+
+function pad_left(inputstring, desired_length, pad_with)
+
+character(len=*), intent(in) :: inputstring
+integer, intent(in) :: desired_length
+character(len=1), intent(in) :: pad_with
+character(len=max(len_trim(inputstring), desired_length)) :: pad_left
+integer :: i
+
+if (len_trim(inputstring) < desired_length) then
+   do i = 1, desired_length - len_trim(inputstring)
+      pad_left(i:i) = pad_with
+   end do
+   pad_left(desired_length - len_trim(inputstring) + 1 : len(pad_left)) = inputstring
+else
+   pad_left = inputstring
+end if      
+
+end function pad_left
 
 !-----------------------------------------------------------------------
 !> dump the contents of a 1d array with a max of N items per line.

--- a/assimilation_code/modules/utilities/utilities_mod.rst
+++ b/assimilation_code/modules/utilities/utilities_mod.rst
@@ -98,6 +98,12 @@ Public interfaces
 \                       set_tasknum
 \                       set_output
 \                       do_output
+\                       string_to_real
+\                       string_to_integer
+\                       integer_to_string
+\                       string_to_logical
+\                       pad_left
+\                       zero_fill
 \                       E_DBG, DEBUG
 \                       E_MSG, MESSAGE
 \                       E_WARN, WARNING
@@ -581,6 +587,74 @@ A note about documentation style. Optional arguments are enclosed in brackets *[
    ======= ======================================
    ``var`` True if this task should write output.
    ======= ======================================
+
+| 
+
+.. container:: routine
+
+   *resulting_string = integer_to_string(input_integer)*
+   
+   .. code-block::
+
+      integer, intent(in) :: input_integer
+      character(len=32) :: resulting_string
+
+.. container:: indent1
+
+   Takes an ``input_integer`` and returns a string analog of said integer.
+
+   ================= ===========
+   ``input_integer`` any integer
+   ================= ===========
+
+| 
+
+.. container:: routine
+
+   *resulting_string = pad_left(inputstring, desired_length, pad_with)*
+   
+   .. code-block::
+
+      character(len=*), intent(in) :: inputstring
+      integer, intent(in) :: desired_length
+      character(len=1), intent(in) :: pad_with
+      character(len=max(len_trim(inputstring), desired_length)) :: pad_left
+
+.. container:: indent1
+
+   Takes an inputstring and left-pads it with a specified character, ``pad_with``, to return
+   a string of ``desired_length``. If the length of ``inputstring`` is equal to longer than
+   ``desired_length``, ``inputstring`` is returned.
+
+   ================== ================================================
+   ``inputstring``    any character string
+   ``desired_length`` integer specifying length of returned string
+   ``pad_with``       single character used to pad the returned string
+   ================== ================================================
+
+| 
+
+.. container:: routine
+
+   *resulting_string = zero_fill(inputstring, desired_length)*
+
+   .. code-block::
+      
+      character(len=*), intent(in) :: inputstring
+      integer, intent(in) :: desired_length
+      character(len=max(len_trim(inputstring), desired_length)) :: resulting_string
+
+.. container:: indent1
+
+   Takes an inputstring and left-pads it with zeros to return a string of ``desired_length``.
+   If the length of ``inputstring`` is equal to longer than ``desired_length``,
+   ``inputstring`` is returned.
+
+
+   ================== ============================================
+   ``inputstring``    any character string
+   ``desired_length`` integer specifying length of returned string
+   ================== ============================================
 
 | 
 

--- a/conf.py
+++ b/conf.py
@@ -17,11 +17,11 @@
 # -- Project information -----------------------------------------------------
 
 project = 'DART'
-copyright = '2023, University Corporation for Atmospheric Research'
+copyright = '2024, University Corporation for Atmospheric Research'
 author = 'Data Assimilation Research Section'
 
 # The full version, including alpha/beta/rc tags
-release = '11.0.3'
+release = '11.0.4'
 root_doc = 'index'
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
## Description:
Adds three functions to utilities_mod: zero_fill, pad_left and integer_to_string

### Fixes issue
#645 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation update

### Documentation changes needed?
- [X] My change requires a change to the documentation.
  - [X] I have updated the documentation accordingly.

### Tests
I used all three functions in a test version of the lorenz_96 model_mod to ensure they work properly, testing edge cases such as passing the zero_fill and pad_left functions `desired_length = 0` or passing an inputstring equal to the value of `desired_length`.

## Checklist for merging

- [X] Updated changelog entry
- [X] Documentation updated
- [X] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [X] No dataset needed
