### PR TITLE
Add WRF hybrid vertical coordinate 

### DIFF
--- a/models/wrf/model_mod.f90
+++ b/models/wrf/model_mod.f90
@@ -5316,8 +5316,7 @@ ph_e = ( (x_iphp1 + wrf%dom(id)%phb(i,j,k+1)) &
 ! now calculate rho = - mu / dphi/deta
 
 if (wrf%dom(id)%hybrid_opt == VERT_HYBRID) then
-   model_rho_t_distrib(:) = - (wrf%dom(id)%c1h(k)*wrf%dom(id)%mub(i,j)+wrf%dom(id)%c2h(k) + &
-        wrf%dom(id)%c1h(k)*x_imu) / ph_e
+   model_rho_t_distrib(:) = - (wrf%dom(id)%c1h(k)*(wrf%dom(id)%mub(i,j)+x_imu) + wrf%dom(id)%c2h(k)) / ph_e
 else
    model_rho_t_distrib(:) = - (wrf%dom(id)%mub(i,j)+x_imu) / ph_e
 endif


### PR DESCRIPTION
## Description:
<!--- Describe your changes -->
Adds the ability for DART to detect whether WRF is using Hybrid Vertical Coordinate (HVC) or terrain following (TF) system.  WRF added this capability starting in WRFv3.9.  The DART code automatically identifies the coordinate system by identifying coordinate attribute information within WRF file.  Also compatible with pre WRFv3.9 versions which did not include explicit attribute information for vertical coordinate system.

### Fixes issue
<!--- link to github issue(s) -->
Fixes issue #649 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.


## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [ ] No dataset needed
