### PR TITLE
Add stage "assim" and optional obs_seq write to outline

### DIFF
--- a/assimilation_code/programs/filter/filter.rst
+++ b/assimilation_code/programs/filter/filter.rst
@@ -160,10 +160,13 @@ The detailed execution flow inside the filter program is:
    -  If requested, compute and write the "postassim" netcdf diagnostic files (members, mean, spread). This is BEFORE
       any posterior inflation has been applied.
    -  Apply posterior inflation if requested.
+   -  If requested, compute and write the "analysis" netcdf diagnostic files (members, mean, spread). 
+      This is AFTER any posterior inflation has been applied.
    -  Compute ensemble of posterior observation values with forward operators.
    -  Compute posterior observation space diagnostics.
-   -  If requested, compute and write out the "output" netcdf diagnostic files (members, mean, spread). This is AFTER
-      any posterior inflation has been applied.
+   -  If requested (for debugging) write observations available at this time to the observation sequence file.
+   -  If requested, compute and write out the "output" netcdf diagnostic files (members, mean, spread). 
+      This is AFTER any posterior inflation has been applied.
    -  Loop until all observations in input file processed.
 
 -  Close diagnostic files.

--- a/assimilation_code/programs/filter/filter.rst
+++ b/assimilation_code/programs/filter/filter.rst
@@ -157,19 +157,18 @@ The detailed execution flow inside the filter program is:
          -  Apply increments to any remaining unassimilated observations.
          -  Loop until all observations in window processed.
 
+   -  If requested, apply posterior inflation damping.
    -  If requested, compute and write the "postassim" netcdf diagnostic files (members, mean, spread). This is BEFORE
       any posterior inflation has been applied.
    -  Apply posterior inflation if requested.
-   -  If requested, compute and write the "analysis" netcdf diagnostic files (members, mean, spread). 
-      This is AFTER any posterior inflation has been applied.
    -  Compute ensemble of posterior observation values with forward operators.
    -  Compute posterior observation space diagnostics.
-   -  If requested (for debugging) write observations available at this time to the observation sequence file.
-   -  If requested, compute and write out the "output" netcdf diagnostic files (members, mean, spread). 
+   -  If requested, compute and write the "analysis" netcdf diagnostic files (members, mean, spread). 
       This is AFTER any posterior inflation has been applied.
-   -  Loop until all observations in input file processed.
+   -  Loop through assimilation windows until all observations in obs_seq.out have been processed.
 
--  Close diagnostic files.
+-  If requested, compute and write out the "output" netcdf diagnostic files (members, mean, spread). 
+   This is AFTER any posterior inflation has been applied.
 -  Write out final observation sequence file.
 -  Write out inflation restart files if requested.
 -  Write out final state vectors to model restart files if requested.


### PR DESCRIPTION
## Description:
The "Detailed program execution" in filter.rst is missing the "assim" stage.
I also added a line about the optional writing of partial obs_seq file contents.

What difference can there be between the "assim" and "output" stages?
It's not the posterior inflation; that's done before "assim".

### Fixes issue
#227

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.

### Tests
I remade the documentation with `make html` operating on this new branch.

## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [ ] No dataset needed
