### PR TITLE
prevent hang by erroring out if shortest_time_between_assimilations <=0

### DIFF
--- a/assimilation_code/modules/assimilation/obs_model_mod.f90
+++ b/assimilation_code/modules/assimilation/obs_model_mod.f90
@@ -157,6 +157,9 @@ call get_ensemble_time(ens_handle, 1, ens_time)
 
 ! Compute the model time step and center a window around the closest time
 delta_time = get_model_time_step()
+if (delta_time <= set_time(0,0)) then
+   call error_handler(E_ERR, 'move_ahead', 'shortest_time_between_assimilations must be > 0', source)
+endif
 
 ! print out current window, if requested
 if (print_trace_details > 0) then


### PR DESCRIPTION
## Description:
<!--- Describe your changes -->

Catch and error out when shortest_time_between_assimilations/get_model_time_step == 0
This prevents hangs in lower order models (e.g. lorenz_96) and "Inconsistent model state/observation times, cannot continue" in large models.

Note the routine shortest_time_between_assimilations and get_model_time_step are the same routine. 
https://github.com/NCAR/DART/blob/75cf8dc9c566221f624ffd4d5eeba9fde5a1757c/assimilation_code/modules/assimilation/assim_model_mod.f90#L23

### Fixes issue
<!--- link to github issue(s) -->
fixes #535

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

### Tests
Please describe any tests you ran to verify your changes.

lorenz_96 with
``` 
&model_nml
   ...
   time_step_days    = 0,
   time_step_seconds = 0,
   /
```
hangs on main, errors out with message 'shortest_time_between_assimilations must be > 0' with this fix.

wrf with
```
&model_nml
   assimilation_period_seconds = 0,
```
Errors out with message 'shortest_time_between_assimilations must be > 0' with this fix

## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [ ] No dataset needed
