### PR TITLE
Improve defaults for model templates input.nml

### DIFF
--- a/models/template/model_mod.f90
+++ b/models/template/model_mod.f90
@@ -18,7 +18,7 @@ use     location_mod, only : location_type, get_close_type, &
                              loc_get_close_state => get_close_state, &
                              set_location, set_location_missing
 
-use    utilities_mod, only : register_module, error_handler, &
+use    utilities_mod, only : error_handler, &
                              E_ERR, E_MSG, &
                              nmlfileunit, do_output, do_nml_file, do_nml_term,  &
                              find_namelist_in_file, check_namelist_read
@@ -91,9 +91,6 @@ subroutine static_init_model()
 integer  :: iunit, io
 
 module_initialized = .true.
-
-! Print module information to log file and stdout.
-call register_module(source)
 
 call find_namelist_in_file("input.nml", "model_nml", iunit)
 read(iunit, nml = model_nml, iostat = io)

--- a/models/template/oned_model_mod.f90
+++ b/models/template/oned_model_mod.f90
@@ -71,7 +71,6 @@ public :: pert_model_copies,      &
           read_model_time, &
           write_model_time
 
-! version controlled file description for error handling, do not edit
 character(len=256), parameter :: source   = "new_model.f90"
 
 type(location_type), allocatable :: state_loc(:)  ! state locations, compute once and store for speed
@@ -100,11 +99,18 @@ contains
 
 subroutine static_init_model()
 
+integer  :: iunit, io
 real(r8) :: x_loc
 integer  :: i, dom_id
 
-! Do any initial setup needed, including reading the namelist values
-call initialize()
+! Read the namelist 
+call find_namelist_in_file("input.nml", "model_nml", iunit)
+read(iunit, nml = model_nml, iostat = io)
+call check_namelist_read(iunit, io, "model_nml")
+
+! Output the namelist values if requested
+if (do_nml_file()) write(nmlfileunit, nml=model_nml)
+if (do_nml_term()) write(     *     , nml=model_nml)
 
 ! Create storage for locations
 allocate(state_loc(model_size))
@@ -273,27 +279,6 @@ location = state_loc(index_in)
 if (present(qty_type)) qty_type = QTY_STATE_VARIABLE 
 
 end subroutine get_state_meta_data
-
-
-
-!------------------------------------------------------------------
-! Do any initialization/setup, including reading the
-! namelist values.
-
-subroutine initialize()
-
-integer :: iunit, io
-
-! Read the namelist 
-call find_namelist_in_file("input.nml", "model_nml", iunit)
-read(iunit, nml = model_nml, iostat = io)
-call check_namelist_read(iunit, io, "model_nml")
-
-! Output the namelist values if requested
-if (do_nml_file()) write(nmlfileunit, nml=model_nml)
-if (do_nml_term()) write(     *     , nml=model_nml)
-
-end subroutine initialize
 
 
 !------------------------------------------------------------------

--- a/models/template/oned_model_mod.f90
+++ b/models/template/oned_model_mod.f90
@@ -19,7 +19,7 @@ use location_mod,          only : location_type, set_location, get_location,  &
                                   get_close_obs, get_close_state,             &
                                   convert_vertical_obs, convert_vertical_state
 
-use utilities_mod,         only : register_module, do_nml_file, do_nml_term,    &
+use utilities_mod,         only : do_nml_file, do_nml_term,    &
                                   nmlfileunit, find_namelist_in_file,           &
                                   check_namelist_read
 
@@ -283,9 +283,6 @@ end subroutine get_state_meta_data
 subroutine initialize()
 
 integer :: iunit, io
-
-! Print module information
-call register_module(source)
 
 ! Read the namelist 
 call find_namelist_in_file("input.nml", "model_nml", iunit)

--- a/models/template/threed_model_mod.f90
+++ b/models/template/threed_model_mod.f90
@@ -18,7 +18,7 @@ use     location_mod, only : location_type, get_close_type, &
                              loc_get_close_state => get_close_state, &
                              set_location, set_location_missing
 
-use    utilities_mod, only : register_module, error_handler, &
+use    utilities_mod, only : error_handler, &
                              E_ERR, E_MSG, &
                              nmlfileunit, do_output, do_nml_file, do_nml_term,  &
                              find_namelist_in_file, check_namelist_read
@@ -91,9 +91,6 @@ subroutine static_init_model()
 integer  :: iunit, io
 
 module_initialized = .true.
-
-! Print module information to log file and stdout.
-call register_module(source)
 
 call find_namelist_in_file("input.nml", "model_nml", iunit)
 read(iunit, nml = model_nml, iostat = io)

--- a/models/template/work/threed_input.nml
+++ b/models/template/work/threed_input.nml
@@ -7,11 +7,11 @@
 
 &perfect_model_obs_nml
    read_input_state_from_file = .true.,
-   single_file_in             = .true.
+   single_file_in             = .false.
    input_state_files          = "perfect_input.nc"
 
    write_output_state_to_file = .true.,
-   single_file_out            = .true.
+   single_file_out            = .false.
    output_state_files         = "perfect_output.nc"
    output_interval            = 1,
 
@@ -20,8 +20,8 @@
 
    obs_seq_in_file_name       = "obs_seq.in",
    obs_seq_out_file_name      = "obs_seq.out",
-   init_time_days             = 0,
-   init_time_seconds          = 0,
+   init_time_days             = -1,
+   init_time_seconds          = -1,
    first_obs_days             = -1,
    first_obs_seconds          = -1,
    last_obs_days              = -1,
@@ -35,7 +35,7 @@
    /
 
 &filter_nml
-   single_file_in               = .true.,
+   single_file_in               = .false.,
    input_state_files            = ''
    input_state_file_list        = 'filter_input_list.txt'
 
@@ -63,8 +63,8 @@
    obs_sequence_in_name         = "obs_seq.out",
    obs_sequence_out_name        = "obs_seq.final",
    num_output_obs_members       = 20,
-   init_time_days               = 0,
-   init_time_seconds            = 0,
+   init_time_days               = -1,
+   init_time_seconds            = -1,
    first_obs_days               = -1,
    first_obs_seconds            = -1,
    last_obs_days                = -1,
@@ -93,7 +93,7 @@
    /
 
 &assim_tools_nml
-   cutoff                          = 1000000.0
+   cutoff                          = 0.2
    sort_obs_inc                    = .false.,
    spread_restoration              = .false.,
    sampling_error_correction       = .false.,
@@ -120,7 +120,7 @@
    /
 
 &obs_kind_nml
-   assimilate_these_obs_types = 'RAW_STATE_VARIABLE'
+   assimilate_these_obs_types = ''
    evaluate_these_obs_types   = ''
    /
 
@@ -130,11 +130,9 @@
    /
 
 &utilities_nml
-   TERMLEVEL = 1,
    module_details = .false.,
    logfilename = 'dart_log.out',
    nmlfilename = 'dart_log.nml',
-   write_nml   = 'none'
    /
 
 &preprocess_nml
@@ -147,27 +145,39 @@
    /
 
 &obs_sequence_tool_nml
-   filename_seq      = 'obs_seq.one', 'obs_seq.two',
-   filename_out      = 'obs_seq.processed',
-   first_obs_days    = -1,
-   first_obs_seconds = -1,
-   last_obs_days     = -1,
-   last_obs_seconds  = -1,
-   print_only        = .false.,
-   gregorian_cal     = .false.
-   /
+   num_input_files   = 1,  
+   filename_seq      = 'obs_seq.out',
+   filename_out      = 'obs_seq.processed', 
+   first_obs_days    = -1, 
+   first_obs_seconds = -1, 
+   last_obs_days     = -1, 
+   last_obs_seconds  = -1, 
+   obs_types         = '', 
+   keep_types        = .false., 
+   print_only        = .false., 
+   min_lat           = -90.0, 
+   max_lat           =  90.0, 
+   min_lon           =   0.0, 
+   max_lon           = 360.0,
+   /   
 
 &obs_diag_nml
-   obs_sequence_name     = 'obs_seq.final',
-   bin_width_days        = -1,
-   bin_width_seconds     = -1,
-   init_skip_days        = 0,
-   init_skip_seconds     = 0,
-   Nregions              = 3,
-   trusted_obs           = 'null',
-   lonlim1               = 0.00, 0.00, 0.50
-   lonlim2               = 1.01, 0.50, 1.01
-   reg_names             = 'whole', 'yin', 'yang'
+   obs_sequence_name  = 'obs_seq.final',
+   obs_sequence_list  = '',
+   first_bin_center   =  2003, 1, 1, 0, 0, 0 ,
+   last_bin_center    =  2003, 1, 2, 0, 0, 0 ,
+   bin_separation     =     0, 0, 0,12, 0, 0 ,
+   bin_width          =     0, 0, 0, 6, 0, 0 ,
+   time_to_skip       =     0, 0, 0, 0, 0, 0 ,
+   max_num_bins       = 1000,
+   trusted_obs        = 'null',
+   Nregions   = 4,
+   lonlim1    =   0.0,   0.0,   0.0, 235.0,
+   lonlim2    = 360.0, 360.0, 360.0, 295.0,
+   latlim1    =  20.0, -80.0, -20.0,  25.0,
+   latlim2    =  80.0, -20.0,  20.0,  55.0,
+   reg_names  = 'Northern Hemisphere', 'Southern Hemisphere', 'Tropics', 'North America',
+   print_mismatched_locs = .false.,
    create_rank_histogram = .true.,
    outliers_in_histogram = .true.,
    use_zero_error_obs    = .false.,


### PR DESCRIPTION
## Description:
<!--- Describe your changes -->
The templates for 3d models did not have good defaults for single files/obs_diag
This had tripped up users adding new models. 
This pull request provides improved defaults, and removes some svn relics from the templates model_mods (register_model)
Moved the oned initialize routine contents to static_init_model.

### Fixes issue
<!--- link to github issue(s) -->
fixes #493

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

### Tests
created a oned and threed_sphere new model, checked that quickbuild.sh was successful for both

./new_model.sh a_1d_model oned
./new_model.sh a_3d_model threed_sphere

For the defaults, compared threed_sphere with wrf input.nml

## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [x] No dataset needed
