### PR TITLE
Notify user if using RTPS inflation that QCEFF options ignored for posterior inflation

### DIFF
--- a/assimilation_code/modules/assimilation/filter_mod.f90
+++ b/assimilation_code/modules/assimilation/filter_mod.f90
@@ -438,6 +438,12 @@ if (do_output()) then
                                       inf_damping(POSTERIOR_INF), ' will be used'
       call error_handler(E_MSG,'filter_main:', msgstring)
    endif
+   if (do_rtps_inflate(post_inflate)) then
+      write(msgstring, *) 'Posterior inflation is RTPS, QCEFF ', &
+                              'inflation options will be ignored for posterior inflation'
+      call error_handler(E_MSG,'filter_main:', msgstring)
+   endif
+
 endif
 
 call trace_message('After  initializing inflation')

--- a/guide/qceff_probit.rst
+++ b/guide/qceff_probit.rst
@@ -48,6 +48,11 @@ options as columns of the qceff_table:
      * lower_bound    (default -888888)
      * upper_bound    (default -888888)
 
+   .. note::
+
+      If using RTPS inflation, the probit distribution information is ignored for posterior
+      inflation.
+
 
 * Observation increment information
 


### PR DESCRIPTION
## Description:
<!--- Describe your changes -->
If RTPS inflation is selected, the probit inflation qceff options are silently ignored for posterior inflation. 
This pull request adds a message from filter to notify the user, and adds a note in the qceff docs about RTPS.

### Fixes issue
<!--- link to github issue(s) -->
fixes #748
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.

### Tests
Please describe any tests you ran to verify your changes.

Run lorenz_96_tracer with RTPS inflation (posterior inf_flavor = 4) to check the message is printed (and not printed for post inf_flavor /= 4)

## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [ ] No dataset needed
