### PR TITLE
Modified oned/obs_diag.f90 to add an unused singleton level

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,13 @@ individual files.
 
 The changes are now listed with the most recent at the top.
 
+**January 9 2024 :: Bug-fix 1D obs_diag. Tag v11.8.7**
+
+- Added a dummy dimension so 1D obs_diag output can be used with 
+  MATLAB diagnostic tools
+- Added a notification that probit inflation QCEFF options are ignored 
+  for RTPS
+
 **December 6 2024 :: Developer tests. Tag v11.8.6**
 
 - Tests for distribution modules: normal, beta, gamma

--- a/conf.py
+++ b/conf.py
@@ -21,7 +21,7 @@ copyright = '2023, University Corporation for Atmospheric Research'
 author = 'Data Assimilation Research Section'
 
 # The full version, including alpha/beta/rc tags
-release = '11.8.7'
+release = '11.8.8'
 root_doc = 'index'
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
Modified oned/obs_diag.f90 to add an unused singleton level
dimension to the output netcdf fields. These files now work with all of the relevant observation space diagnostic matlab programs. This was tested for plot_rank_histogram.m, plot_evolution.m, and plot_rmse_xxx_evolution.m for lorenz_96, lorenz_63, lorenz_84, and lorenz_96_tracer_advection, the latter with multiple observation types.

## Description:
Added a new level dimension, added extra dimensions to array that processes the input from the obs_seq file.

### Fixes issue 230
fixes https://github.com/NCAR/DART/issues/230

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

### Tests
See summary.

## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [x] No dataset needed
