### PR TITLE
fix lorenz_93 and lorenz_63 workshop input.nmls to have v11 version of namelist

### DIFF
--- a/models/lorenz_63/work/input.workshop.nml
+++ b/models/lorenz_63/work/input.workshop.nml
@@ -1,3 +1,10 @@
+&probit_transform_nml
+   /
+
+&algorithm_info_nml
+   qceff_table_filename = ''
+   /
+
 &perfect_model_obs_nml
    read_input_state_from_file = .true.,
    single_file_in             = .true.
@@ -86,7 +93,6 @@
    /
 
 &assim_tools_nml
-   filter_kind                     = 1,
    cutoff                          = 0.00001,
    sort_obs_inc                    = .false.,
    spread_restoration              = .false.,
@@ -135,11 +141,12 @@
    /
 
 &preprocess_nml
-    input_obs_def_mod_file = '../../../observations/forward_operators/DEFAULT_obs_def_mod.F90', 
-   output_obs_def_mod_file = '../../../observations/forward_operators/obs_def_mod.f90', 
-   input_obs_kind_mod_file = '../../../assimilation_code/modules/observations/DEFAULT_obs_kind_mod.F90', 
-  output_obs_kind_mod_file = '../../../assimilation_code/modules/observations/obs_kind_mod.f90', 
-               input_files = '../../../observations/forward_operators/obs_def_1d_state_mod.f90'
+   input_obs_def_mod_file  = '../../../observations/forward_operators/DEFAULT_obs_def_mod.F90'
+   output_obs_def_mod_file = '../../../observations/forward_operators/obs_def_mod.f90'
+   input_obs_qty_mod_file  = '../../../assimilation_code/modules/observations/DEFAULT_obs_kind_mod.F90'
+   output_obs_qty_mod_file = '../../../assimilation_code/modules/observations/obs_kind_mod.f90'
+   obs_type_files          = '../../../observations/forward_operators/obs_def_1d_state_mod.f90'
+   quantity_files          = '../../../assimilation_code/modules/observations/oned_quantities_mod.f90'
    /
 
 &obs_sequence_tool_nml

--- a/models/lorenz_96/work/input.workshop.nml
+++ b/models/lorenz_96/work/input.workshop.nml
@@ -1,3 +1,10 @@
+&probit_transform_nml
+   /
+
+&algorithm_info_nml
+   qceff_table_filename = ''
+   /
+
 &perfect_model_obs_nml
    read_input_state_from_file = .true.,
    single_file_in             = .true.
@@ -89,7 +96,6 @@
 # large for the model to converge.  to test that the model is 
 # doing a successful assimilation, change cutoff to 0.02 and rerun.
 &assim_tools_nml
-   filter_kind                     = 1,
    cutoff                          = 1000000.0,
    sort_obs_inc                    = .false.,
    spread_restoration              = .false.,
@@ -145,12 +151,12 @@
    /
 
 &preprocess_nml
-          overwrite_output = .true.,
-    input_obs_def_mod_file = '../../../observations/forward_operators/DEFAULT_obs_def_mod.F90',
-   output_obs_def_mod_file = '../../../observations/forward_operators/obs_def_mod.f90',
-   input_obs_kind_mod_file = '../../../assimilation_code/modules/observations/DEFAULT_obs_kind_mod.F90',
-  output_obs_kind_mod_file = '../../../assimilation_code/modules/observations/obs_kind_mod.f90',
-               input_files = '../../../observations/forward_operators/obs_def_1d_state_mod.f90',
+   input_obs_def_mod_file  = '../../../observations/forward_operators/DEFAULT_obs_def_mod.F90'
+   output_obs_def_mod_file = '../../../observations/forward_operators/obs_def_mod.f90'
+   input_obs_qty_mod_file  = '../../../assimilation_code/modules/observations/DEFAULT_obs_kind_mod.F90'
+   output_obs_qty_mod_file = '../../../assimilation_code/modules/observations/obs_kind_mod.f90'
+   obs_type_files          = '../../../observations/forward_operators/obs_def_1d_state_mod.f90'
+   quantity_files          = '../../../assimilation_code/modules/observations/oned_quantities_mod.f90'
    /
 
 &obs_sequence_tool_nml


### PR DESCRIPTION
## Description:
<!--- Describe your changes -->
Added probit_transform_nml and algorithm_info_nml to the 
input.workshop.nmls that were missing these (lorenz_63 and lorenz_96)
so the workshop_setup.sh scripts run to completion.
 
Updated the preprocess_nml to use obs_type quantity files. 

### Fixes issue
<!--- link to github issue(s) -->
fixes #789

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

### Tests
Please describe any tests you ran to verify your changes.

Ran all the workshop_setup.sh scripts

## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [ ] No dataset needed
