### PR TITLE
doc-fix: link for obs_selection

### DIFF
--- a/assimilation_code/programs/obs_common_subset/obs_common_subset.rst
+++ b/assimilation_code/programs/obs_common_subset/obs_common_subset.rst
@@ -29,7 +29,7 @@ supplied with DART to directly compare the observation diagnostic output from mu
 (it does more than two, the script has a poor name).
 
 This is one of a set of tools which operate on observation sequence files. For a more general purpose tool see the
-:doc:`../obs_sequence_tool/obs_sequence_tool`, and for a more flexible selection tool see the obs_selection_tool.
+:ref:`obs sequence tool`, and for a more flexible selection tool see the :ref:`obs_selection`.
 
 Creating an input filelist
 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/assimilation_code/programs/obs_selection/obs_selection.rst
+++ b/assimilation_code/programs/obs_selection/obs_selection.rst
@@ -1,3 +1,5 @@
+.. index:: obs selection 
+
 .. _obs_selection:
 
 program ``obs_selection``

--- a/assimilation_code/programs/obs_selection/obs_selection.rst
+++ b/assimilation_code/programs/obs_selection/obs_selection.rst
@@ -1,3 +1,5 @@
+.. _obs_selection:
+
 program ``obs_selection``
 =========================
 


### PR DESCRIPTION
## Description:
<!--- Describe your changes -->
partial fix for #808, the link to the  obs_selection program was missing. 

changed link for obs_sequence tool to use the anchor rather than a relative path

### Fixes issue
<!--- link to github issue(s) -->
partial #808

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

### Tests
Please describe any tests you ran to verify your changes.

## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [ ] No dataset needed
