### PR TITLE
Check for THM USE_THETA_M attribute

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,11 @@ individual files.
 
 The changes are now listed with the most recent at the top.
 
+**March 14 2025 :: WRF use_theta_m check. Tag v11.10.5**
+
+- Assert USE_THETA_M=0 in WRF when initializing wrf model_mod.
+- fixed documentation broken links.
+
 **February 6 2025 :: WRF tutorial and prepbufr documentation. Tag v11.10.4**
 
 - Observation section of WRF tutorial updated to match provided obs.   

--- a/conf.py
+++ b/conf.py
@@ -21,7 +21,7 @@ copyright = '2023, University Corporation for Atmospheric Research'
 author = 'Data Assimilation Research Section'
 
 # The full version, including alpha/beta/rc tags
-release = '11.10.4'
+release = '11.10.5'
 root_doc = 'index'
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
## Description:
Mandate in WRF-DART that if THM variable is present in &model_nml it must be ' perturbed dry adiabatic potential temperature'.   This is set through USE_THETA_M option in WRF &dynamics namelist.

### Fixes issue
Fixes #837 

### Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Documentation changes needed?
None required.


## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [ ] No dataset needed
