### PR TITLE
fix: vtec extrapolation calculation in TIEGCM

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,12 @@ individual files.
 
 The changes are now listed with the most recent at the top.
 
+**May 1 2025 :: Bug-fixes: TIEGCM, BNRH. Tag v11.10.9**
+
+- Fix VTEC extrapolation calculation in TIEGCM model_mod.
+- Fix loop limit in bnrh_distribution_mod, and routine name in error messages.
+- Documentation fix for perturb_single_instance.
+
 **April 22 2025 :: Bug-fix: CICE interpolation. Tag v11.10.8**
 
 - Inverse distance weighting interpolation for CICE. Replaces

--- a/conf.py
+++ b/conf.py
@@ -21,7 +21,7 @@ copyright = '2023, University Corporation for Atmospheric Research'
 author = 'Data Assimilation Research Section'
 
 # The full version, including alpha/beta/rc tags
-release = '11.10.8'
+release = '11.10.9'
 root_doc = 'index'
 
 # -- General configuration ---------------------------------------------------

--- a/models/tiegcm/model_mod.f90
+++ b/models/tiegcm/model_mod.f90
@@ -7,7 +7,6 @@
 !  - Nick Dietrich fix_mmr. When do to this?
 !  - model_time
 !  - get_state_meta_data 2D variables
-!  - test vtec
 
 module model_mod
 
@@ -379,9 +378,9 @@ endif ! end of QTY_PRESSURE
 if ( iqty == QTY_VERTICAL_TEC ) then ! extrapolate vtec
 
    call extrapolate_vtec(state_handle, ens_size, lon_below, lat_below, val11)
-   call extrapolate_vtec(state_handle, ens_size, lon_below, lat_above, val11)
-   call extrapolate_vtec(state_handle, ens_size, lon_above, lat_below, val11)
-   call extrapolate_vtec(state_handle, ens_size, lon_above, lat_above, val11)
+   call extrapolate_vtec(state_handle, ens_size, lon_below, lat_above, val12)
+   call extrapolate_vtec(state_handle, ens_size, lon_above, lat_below, val21)
+   call extrapolate_vtec(state_handle, ens_size, lon_above, lat_above, val22)
    obs_val(:) = interpolate(ens_size, lon_fract, lat_fract, val11, val12, val21, val22)
    istatus(:) = 0
 
@@ -1111,7 +1110,7 @@ enddo
 ! ZG (interfaces)
 do i = 1, nilev
   idx = get_dart_vector_index(lon_index,lat_index, i, &
-                         domain_id(RESTART_DOM), var_id)
+                        domain_id(SECONDARY_DOM), ivarZG)
   ZG(i, :) = get_state(idx, state_handle)
 enddo
 
@@ -1135,6 +1134,7 @@ enddo
 
 earth_radiusm = earth_radius * 1000.0_r8 ! Convert earth_radius in km to m
 NE            = NE * 1.0e+6_r8           ! Convert NE in #/cm^3 to #/m^3
+ZG            = ZG * 1.0e-2_r8           ! Convert ZG in cm to m
 
 ! Gravity at the top layer
 GRAVITYtop(:) = gravity * (earth_radiusm / (earth_radiusm + ZG(nilev,:))) ** 2


### PR DESCRIPTION
## Description:
<!--- Describe your changes -->
Fixes problems in model_interpolate for VTEC 

- result of 4 corners was not being stored correctly, overwriting corner11
- domain of ZG was incorrect
- units of ZG for need to be m in the vtec calculation

I've taken out the todo "test vtec" 🙃 

### Fixes issue
<!--- link to github issue(s) -->
fixes #851

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

### Tests
None yet, just compiled user reported changes.  
Derecho is down today. 

## Checklist for merging

- [x] Updated changelog entry
- [ ] Documentation updated
- [x] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [ ] No dataset needed
