### PR TITLE
Update WRF lat-lon and cassini  map projection integer

### DIFF
--- a/models/wrf/model_mod.f90
+++ b/models/wrf/model_mod.f90
@@ -7127,7 +7127,7 @@ subroutine read_wrf_file_attributes(ncid,id)
 ! id:   input, domain id
 
 integer, intent(in)   :: ncid, id
-logical, parameter    :: debug = .true.
+logical, parameter    :: debug = .false.
 integer :: ret
 
 ! get meta data and static data we need

--- a/models/wrf/model_mod.f90
+++ b/models/wrf/model_mod.f90
@@ -274,10 +274,8 @@ integer, allocatable  :: domain_id(:) ! Global storage to interface with state_s
 
 ! Private definition of domain map projection use by WRF
 
-!nc -- added in CASSINI and CYL according to module_map_utils convention
-!JPH -- change variable name from map_sphere to more specific map_latlon
-integer, parameter :: map_latlon = 0, map_lambert = 1, map_polar_stereo = 2, map_mercator = 3
-integer, parameter :: map_cassini = 6, map_cyl = 5
+integer, parameter :: map_lambert = 1, map_polar_stereo = 2, map_mercator = 3
+integer, parameter :: map_cyl = 5, map_latlon = 6, map_cassini = 106
 
 ! Private definition of model variable types
 
@@ -7129,7 +7127,7 @@ subroutine read_wrf_file_attributes(ncid,id)
 ! id:   input, domain id
 
 integer, intent(in)   :: ncid, id
-logical, parameter    :: debug = .false.
+logical, parameter    :: debug = .true.
 integer :: ret
 
 ! get meta data and static data we need

--- a/models/wrf/module_map_utils.f90
+++ b/models/wrf/module_map_utils.f90
@@ -87,6 +87,38 @@ end module misc_definitions_module
 
 MODULE map_utils
 
+! IMPORTANT. WRF-DART USERS PLEASE READ.
+! --------------------------------------
+! The remainder of this DART code was adopted directly from
+! the WRF Preprocessing system (WPS) source code 
+! See https://github.com/wrf-model/WPS
+! ~/geogrid/src/module_map_utils.f90.  All comments
+! below here were made from the WPS code.
+
+! The vast majority of applications of WRF-DART are used
+! with the WRF research version (WRF-ARW) where there are 
+! only 4 supported map projections for real data simulations: 
+! 1) Lamert Conformal, 2) Mercator 3) Polar Stereographic and 
+! 4) lat-lon (cylindrical equidistant).
+
+! There are other map projections supported in this code, but
+! most DART users will not use them and the following description
+! is for informational purposes only.  Other model versions of WRF
+! (e.g. ideal WRF cases) use cartesian coordinates. WRF-NMM  
+! (Nonhydrostic Mesoscale Model) uses rotated lat-lon coordinates.
+
+! Other map projections are not supported by any versions of WRF, but
+! are included in this code because they are required by the WRF
+! preprocessing code (WPS) to use input data to generate initial and
+! boundary conditions for WRF (i.e. geogrid, metgrid and real steps). 
+! The input data itself can be in these unsupported projections thus
+! are included here.  These projections include polar stereographic 
+! ellipsoid (WGS84), Albers Equal Area (NAD83), Cassini, Gaussian, 
+! and Cylindrical.
+
+! END WRF-DART specific comments
+! ------------------------------        
+
 ! Module that defines constants, data structures, and
 ! subroutines used to convert grid indices to lat/lon
 ! and vice versa.   
@@ -324,8 +356,6 @@ MODULE map_utils
 
    END SUBROUTINE map_init
 
-
-!nc -- Global WRF assumes proj_code = PROJ_CASSINI (=6 in misc_definitions_module)
 
    SUBROUTINE map_set(proj_code, proj, lat1, lon1, lat0, lon0, knowni, knownj, dx, latinc, &
                       loninc, stdlon, truelat1, truelat2, nlat, nlon, ixdim, jydim, &
@@ -1558,8 +1588,6 @@ MODULE map_utils
       if (i > 360.0_r8/proj%loninc) i = i - 360.0_r8/proj%loninc
 
       i = i + proj%knowni
-!nc -- typo in original I am assuming 
-!nc -- orig -->     j = j + proj%knowni
       j = j + proj%knownj
 
    END SUBROUTINE llij_cyl

--- a/models/wrf/module_map_utils.f90
+++ b/models/wrf/module_map_utils.f90
@@ -71,15 +71,15 @@ module misc_definitions_module
    integer, parameter :: BIG_ENDIAN=0, LITTLE_ENDIAN=1
 
    ! Projection codes for proj_info structure:
-   INTEGER, PUBLIC, PARAMETER  :: PROJ_LATLON       = 0
    INTEGER, PUBLIC, PARAMETER  :: PROJ_LC           = 1
    INTEGER, PUBLIC, PARAMETER  :: PROJ_PS           = 2
    INTEGER, PUBLIC, PARAMETER  :: PROJ_PS_WGS84     = 102
    INTEGER, PUBLIC, PARAMETER  :: PROJ_MERC         = 3
    INTEGER, PUBLIC, PARAMETER  :: PROJ_GAUSS        = 4
    INTEGER, PUBLIC, PARAMETER  :: PROJ_CYL          = 5
-   INTEGER, PUBLIC, PARAMETER  :: PROJ_CASSINI      = 6
+   INTEGER, PUBLIC, PARAMETER  :: PROJ_LATLON       = 6
    INTEGER, PUBLIC, PARAMETER  :: PROJ_ALBERS_NAD83 = 105 
+   INTEGER, PUBLIC, PARAMETER  :: PROJ_CASSINI      = 106
    INTEGER, PUBLIC, PARAMETER  :: PROJ_ROTLL        = 203
 
 end module misc_definitions_module


### PR DESCRIPTION

## Description:
<!--- Describe your changes -->
The WRF lat-lon projection (integer 6) was mismatched with the DART map projection (cassini).  This fix updates the DART projection to match WRF's .

### Fixes issue
Fixes #811 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

### Tests
Ran some quick tests with WRF-DART tutorial

## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [X] No dataset needed
