### PR TITLE
bug-fixes: small bugs in the bnrh_distribution_mod.f90

### DIFF
--- a/assimilation_code/modules/assimilation/bnrh_distribution_mod.f90
+++ b/assimilation_code/modules/assimilation/bnrh_distribution_mod.f90
@@ -204,7 +204,7 @@ logical  :: do_uniform_tail_left, do_uniform_tail_right
 
 ! Given the sorted ensemble (sort_ens) that defines a bnrh CDF and all the corresponding
 ! information about that distribution, computes the value of the CDF for a vector of num
-! elsements (x) and returns those quantiles.
+! elements (x) and returns those quantiles.
 
 ! In the default filter usage, this is only used for doing the probit transform for the
 ! posterior observation ensemble. In this case, the size of vector x is the same as the
@@ -227,7 +227,7 @@ call ens_quantiles(p%ens, p%ens_size, p%bounded_below, p%bounded_above, p%lower_
 ! Loop through the values in the x vector to compute the CDF at each one.
 ! This can be done vastly more efficiently with either binary searches or by first sorting the
 ! vector of values (x) for which the CDF needs to be computed
-do i = 1, p%ens_size
+do i = 1, num
    ! Figure out which bin it is in
    call bnrh_cdf_initialized(x(i), p%ens_size, p%ens, p%bounded_below, p%bounded_above, p%lower_bound, p%upper_bound, &
       tail_amp_left,  tail_mean_left,  tail_sd_left,  do_uniform_tail_left, &

--- a/assimilation_code/modules/assimilation/bnrh_distribution_mod.f90
+++ b/assimilation_code/modules/assimilation/bnrh_distribution_mod.f90
@@ -462,7 +462,7 @@ do i = 1, ens_size
    
    ! Imprecision can lead to x being slightly out of bounds, fix it to bounds
    call check_bounds(x(i), curr_q, bounded_below, lower_bound, &
-                              bounded_above, upper_bound, 'inf_bnrh_cdf')
+                              bounded_above, upper_bound, 'inv_bnrh_cdf')
 enddo
    
 end subroutine inv_bnrh_cdf
@@ -591,7 +591,7 @@ do i = 1, ens_size
    
    ! Imprecision can lead to x being slightly out of bounds, fix it to bounds
    call check_bounds(x(i), curr_q, bounded_below, lower_bound, &
-                              bounded_above, upper_bound, 'inf_bnrh_cdf_like')
+                              bounded_above, upper_bound, 'inv_bnrh_cdf_like')
 enddo
 
 end subroutine inv_bnrh_cdf_like


### PR DESCRIPTION
## Description:
<!--- Describe your changes -->

Corrected the upper limit on loop to compute the CDF at each value in the x vector (subroutine bnrh_cdf_initialized_vector); this needs to be the size of the x vector (num) instead of the size of the ensemble. Also ensured that all the comments now correctly matched the code, which they did without needing any changes

Fixed typos in the names of the calling subroutines passed into check_bounds from the bnrh_distribution_mod (EX: inf_bnrh_cdf -> inv_bnrh_cdf)

### Fixes issue
Fixes issue #844 as well as undocumented typos in call to check_bounds

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

### Tests
Tested bitwise identical using the [Example A (bounded normal rank histogram)](https://docs.dart.ucar.edu/en/latest/guide/qceff-examples.html#example-a:~:text=or%20Microsoft%20Excel.-,Example%20A,-%EF%83%81) of the QCEFF Examples with the Lorenz 96 Tracer Model

## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [x] No dataset needed
