### PR TITLE
fix doc namelist name for perturb_single_instance

### DIFF
--- a/assimilation_code/programs/perturb_single_instance/perturb_single_instance.rst
+++ b/assimilation_code/programs/perturb_single_instance/perturb_single_instance.rst
@@ -16,8 +16,8 @@ namelist.
 
 ::
 
-   &perturb_single_instance
-      ens_size               = ''
+   &perturb_single_instance_nml
+      ens_size               = 50
       input_files            = ''      
       output_files           = ''
       output_file_list       = ''

--- a/assimilation_code/programs/perturb_single_instance/perturb_single_instance.rst
+++ b/assimilation_code/programs/perturb_single_instance/perturb_single_instance.rst
@@ -1,3 +1,5 @@
+.. index:: perturb
+
 PROGRAM ``perturb_single_instance``
 ===================================
 


### PR DESCRIPTION
## Description:
<!--- Describe your changes -->
Allows you to copy the example and paste it into your input.nml without throwing and error for missing namelist.

Also ens_size is an integer so should not be in quotes.

### Fixes issue
<!--- link to github issue(s) -->
fixes #862

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.

### Tests
Please describe any tests you ran to verify your changes.
Built the docs.

## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [x] No dataset needed
