### PR TITLE
Documentation for namelist options for data management and vertical conversion temporal choice

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,7 +22,12 @@ individual files.
 
 The changes are now listed with the most recent at the top.
 
-**June 6 2024 :: Bug-fix: nc_get_variable_info. Tag v11.11.1**
+**July 7 2024 :: Documentation for Data Management. Tag v11.11.2**
+
+- Document namelist options for state distribution and vertical conversion
+- IEEE flag set for Cray Compiler Environment mkmf.template
+
+**June 6 2025 :: Bug-fix: nc_get_variable_info. Tag v11.11.1**
 
 - nc_get_variable_info: Use local variable rather than optional argument which may not be present
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,7 +22,7 @@ individual files.
 
 The changes are now listed with the most recent at the top.
 
-**July 7 2024 :: Documentation for Data Management. Tag v11.11.2**
+**July 7 2025 :: Documentation for Data Management. Tag v11.11.2**
 
 - Document namelist options for state distribution and vertical conversion
 - IEEE flag set for Cray Compiler Environment mkmf.template

--- a/assimilation_code/modules/assimilation/assim_tools_mod.rst
+++ b/assimilation_code/modules/assimilation/assim_tools_mod.rst
@@ -12,6 +12,8 @@ for both mean and spread. In addition, algorithms to do a variety of flavors of 
 particle filter, and kernel filters are included. The parallel implementation that allows each observation to update all
 state variables that are close to it at the same time is described in Anderson and Collins, 2007.
 
+.. _localization:
+
 Localization
 ------------
 

--- a/conf.py
+++ b/conf.py
@@ -21,7 +21,7 @@ copyright = '2023, University Corporation for Atmospheric Research'
 author = 'Data Assimilation Research Section'
 
 # The full version, including alpha/beta/rc tags
-release = '11.11.1'
+release = '11.11.2'
 root_doc = 'index'
 
 # -- General configuration ---------------------------------------------------

--- a/guide/data-management-issues.rst
+++ b/guide/data-management-issues.rst
@@ -5,103 +5,122 @@ Data management in DART
 One of the more challenging aspects of an ensemble Data Assimilation (DA) system 
 is the need to manage large amounts of memory to store ensembles of the model state.
 
-Most contemporary large models run in parallel on multi-processor computer systems 
-and distribute the
-data across multiple memory nodes to support finer grids, smaller timesteps and
-longer modeling time periods.  Common computer science strategies include using
-shared memory on individual nodes and using the Message Passing Interface (MPI) 
-libraries on distributed memory nodes.
+Most modern large-scale models run in parallel on multi-processor computer systems, 
+distributing data across multiple memory nodes to support finer spatial grids, 
+smaller time steps, and longer simulation periods. Common strategies include using 
+shared memory within individual nodes and the Message Passing Interface (MPI) 
+on distributed-memory systems.
 
 Ensemble DA exacerbates this memory problem by requiring multiple copies,
 often 20-100x, of the model data to do the assimilation.
 
-DART uses the MPI libraries to distribute ensembles of model state data across
-distributed memory nodes.  For models with small amounts of data the code can be 
-compiled and run as a serial program but when compiled with MPI 
-it can scale up to 10,000s of nodes using Giga to Petabytes of memory.
+DART uses the Message Passing Interface (MPI) to distribute ensembles of 
+state and extended state data across processors and nodes in a distributed-memory system. 
+For models with relatively small memory demands, DART can be compiled and run as a serial program. 
+However, when compiled with MPI, it can scale to tens of thousands of processors 
+and handle memory requirements ranging from gigabytes to petabytes.
 
-Memory usage and internode communication time are mutually incompatible 
-items to minimize.  DART has different strategies that can be selected
-at runtime to use less memory per node at the cost of more time spent in communication
-of data between nodes, or use more memory per node and minimize communication time.
+There are three phases in DART that require access to the whole state vector:
 
-The following descriptions detail the different phases of the main assimilation
-program in DART, called ``filter``, and what options exist for memory layout
-and management.
+1. IO - reading and writing of the model state.
+2. Forward Operator (FO) computation. 
+3. Conversion of of a observation or state location from one vertical coordinate system to another.
 
-
-Ensembles of data
------------------
-
-State data
-~~~~~~~~~~
-
-* N ensemble members times X items in the state vector, always resident.
-* 6 additional copies of X items for inflation, ensemble mean & sd, etc.
-
-Observations
-~~~~~~~~~~~~
-
-Allocated and deallocated if looping over multiple assimilation windows
-within a single run of filter.
-
-* Only observations within the current assimilation window, O
-* O observations times N ensemble members for the Forward Operator (FO) results
-* O observations times N ensemble members for the QC results
-
-Delayed writing option
-~~~~~~~~~~~~~~~~~~~~~~
-
-If selected in the namelist, up to P phases (input, forecast, preassim, postassim,
-analysis, output) of the state data are stored in memory and written out at the end 
-of filter.
+There is an inherent trade-off between memory usage and internode communication.
+DART provides multiple runtime strategies to balance this trade-off: 
+users can choose to reduce memory usage per process at the cost of increased communication
+overhead, or to use more memory per node in order to minimize data transfer between processes.
+The whole state is always logically visible to all MPI tasks, but physically it may be distributed 
+across multiple tasks.
 
 
-Filter run phases
------------------
+IO - reading and writing of the model state
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-FO computation, prior and posterior
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The first N logical MPI tasks read and write the state vector from disk, where N is the ensemble size.
+The state vector is read into memory in a single MPI task, and then distributed across the
+MPI tasks.  To minimize per node memory and IO contention, the logical MPI tasks are assigned to physical
+MPI tasks in a round-robin fashion.
 
-Run-time options include allocating spaces for two layouts and transposing
-between them, or running distributed in 'all copies' mode.
+Recommended setting for the layout in ensemble_manager_nml:
+
+.. code-block:: text
+
+    &ensemble_manager_nml
+       layout                      = 2
+       tasks_per_node              = 128 ! Note this should match your mpirun settings
+    /
+
+For very large state vectors, you may not be able to read the entire state vector into memory on a single 
+node. In this case you can set ``buffer_state_io = .true.`` in the state_vector_io_nml namelist.
+This will read the state vector in chunks, buffering the data in memory before distributing it across the MPI tasks.
+
+.. Note:: 
+
+    Note buffering state IO has more communication overhead than the default setting of ``buffer_state_io = .false.``,
+    so is only recommended if you have a very large state vector that does not fit into memory on a single node.
 
 
-Assimilation
-~~~~~~~~~~~~
+    .. code-block:: text
 
-Distributed FO and QC observation ensembles
-
-Runtime option to either replicate the model state ensemble mean on each MPI task
-or run with that ensemble fully distributed.
+        &state_vector_io_nml
+           buffer_state_io          = .true.,
+        /
 
 
-Ensemble memory usage and layout
---------------------------------
+Forward Operator (FO) computation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Transposable
-~~~~~~~~~~~~
+The majority of calculation in an assimilation is done across the ensemble, for example,
+means, variances, increments, inflation, etc. and so the ideal data layout for assimilation is to have 
+all ensemble members for a given element of the state vector on the same MPI process. 
+However, :ref:`forward operator <FO>` calculations may need data from any part of the state
+vector, and so the ideal data layout for the forward operator is the entire state vector on 
+the same MPI process.
 
-Data is distributed over T MPI tasks but during the program execution
-the data is communicated between tasks to alternate between two different
-data layouts.
+By default, DART runs in distributed mode, ``distribute_state = .true.`` (ideal for assimilation)
+where each MPI task has all the ensemble members for subset of the state vector.
+The forward operator calculation is vectorized across the whole ensemble, and DART takes 
+care of retrieving any state values needed for the forward operator calculation from other MPI
+tasks. 
 
-Allocations are needed for two different 2D arrays: 
+You may want to run in "transpose mode" where the first N MPI tasks perform the forward operator
+calculation, where N is the ensemble size. This is done by setting the namelist option
+``distributed_state = .false.`` in the filter_nml namelist. In general, this is not recommended
+as it requires more memory per task, has less vectorization, and does not scale beyond N tasks. 
+However, it may be useful
+for debugging.
 
-* N ensemble members times (X items/T tasks)
-* X items times (N ensemble members/T tasks)
+Recommended setting for ``distributed_state``:
 
-Distributed
-~~~~~~~~~~~
+.. code-block:: text
 
-Data is distributed over T MPI tasks but only a single data array
-is used:
+    &filter_nml
+       distributed_state = .true.,
+    /
 
-* N ensemble members times (X items/T tasks)
 
-Replicated
-~~~~~~~~~~
+Conversion of observation or state location
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The same data array is replicated on each MPI task:
+The vertical location of an observation or state element may depend on the model state. For example, 
+an observation might be reported in pressure coordinates, requiring conversion based on the model state.
+For localization calculations, all MPI processes use the ensemble mean state for any vertical coordinate 
+transformations that depend on the model state.
 
-* X items per task
+If your state is small or your system has ample memory, it can be advantageous to store a full copy of the 
+mean on each MPI process for use in vertical calculations. However, if the state is very large and you're 
+approaching (or exceeding) the available memory per node, it may be more efficient to distribute the mean 
+across MPI processes to reduce memory usage
+
+The default for ``distribute_mean`` is ``.false.``  but for models with large state vectors or models that 
+do no vertical coordinate conversions, it may be beneficial to set this to ``.true.``.
+
+.. code-block:: text
+
+    &assim_tools_nml
+       distribute_mean = .false.,
+    /
+
+
+

--- a/guide/data-management-issues.rst
+++ b/guide/data-management-issues.rst
@@ -25,7 +25,7 @@ There are three phases in DART that require access to the whole state vector:
 
 1. IO - reading and writing of the model state.
 2. Forward Operator (FO) computation. 
-3. Conversion of of a observation or state location from one vertical coordinate system to another.
+3. Conversion of an observation or state location from one vertical coordinate system to another.
 
 There is an inherent trade-off between memory usage and internode communication.
 DART provides multiple runtime strategies to balance this trade-off: 
@@ -105,7 +105,8 @@ Conversion of observation or state location
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The vertical location of an observation or state element may depend on the model state. For example, 
-an observation might be reported in pressure coordinates, requiring conversion based on the model state.
+an observation might be reported in pressure coordinates, requiring conversion to, for example, height,
+based on the model state.
 For localization calculations, all MPI tasks use the ensemble mean state for any vertical coordinate 
 transformations that depend on the model state.
 

--- a/guide/data-management-issues.rst
+++ b/guide/data-management-issues.rst
@@ -1,3 +1,4 @@
+.. _data-distribution:
 
 Data management in DART	
 =======================

--- a/guide/data-management-issues.rst
+++ b/guide/data-management-issues.rst
@@ -38,8 +38,8 @@ across multiple tasks.
 IO - reading and writing of the model state
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The first N logical MPI tasks read and write the state vector from disk, where N is the ensemble size.
-The state vector is read into memory in a single MPI task, and then distributed across the
+The first N logical MPI tasks read and write the N state vectors from disk, where N is the ensemble size.
+A state vector is read into memory in a single MPI task, and then distributed across the
 MPI tasks.  To minimize per node memory and IO contention, the logical MPI tasks are assigned to physical
 MPI tasks in a round-robin fashion.
 

--- a/guide/forward_operator.rst
+++ b/guide/forward_operator.rst
@@ -1,3 +1,5 @@
+.. _FO:
+
 =================
 Forward Operators
 =================
@@ -93,7 +95,7 @@ present in the model state.
 See the radar forward operator for an example in the 'expected fall velocity'
 section.  If this has already been computed by the model and is
 available in the model state, the code interpolates in this field
-and returns.  If not, it interpolates values for other consitituent
+and returns.  If not, it interpolates values for other constituent
 fields and does a generic computation.
 
 
@@ -128,12 +130,12 @@ is desired. For example, if the forward operator is being read from a file, or t
 Or when debugging it may be easier to have 1 task per ensemble member.
 
 To transpose and do the forward operators without using MPI one-sided communication, 
-you can use the filter_nml namelist option ``distribute_state = .false.`` 
+you can use the filter_nml namelist option ``distributed_state = .false.`` 
 The process is the same as above except the window creation and destruction are transposing the state.
 
 #. State window created (state ensemble is transposed var complete)
 #. Forward operator called
-#. State window destroyed (state ensemble is tranaposed to copy complete)
+#. State window destroyed (state ensemble is transposed to copy complete)
 #. QC calculated for the ensemble
 
 Note, that if you have fewer tasks than ensemble members some tasks will still be doing vectorized forward operators

--- a/guide/vertical-conversion.rst
+++ b/guide/vertical-conversion.rst
@@ -91,7 +91,7 @@ When deciding to when to convert verticals, consider the following:
   and most of the state is being updated  during assimilation, then converting all state verticals first 
   may be more efficient.
 - If you are :ref:`distributing the mean <data-distribution>` across MPI processes this will increase the cost of
-  of each conversion. You may not want to convert all state verticals first if the mean is distributed and 
+  each conversion. You may not want to convert all state verticals first if the mean is distributed and 
   few state elements are updated.
 - How many observations are being assimilated, e.g. if you have a large number of observations, then converting
   all observation verticals first may be more efficient as the conversion is done in parallel.

--- a/guide/vertical-conversion.rst
+++ b/guide/vertical-conversion.rst
@@ -87,11 +87,11 @@ The default setting for vertical conversion in assim_tools_nml:
 
 When deciding to when to convert verticals, consider the following:
 
-- How many state elements are updated, e.g. if you have a large :ref:`cuttoff <localization>`
+- How many state elements are updated, e.g. if you have a large :ref:`cutoff <localization>`
   and most of the state is being updated  during assimilation, then converting all state verticals first 
   may be more efficient.
 - If you are :ref:`distributing the mean <data-distribution>` across MPI processes this will increase the cost of
-  of each conversion. You many not want to convert all state verticals first if the mean is distributed and 
+  of each conversion. You may not want to convert all state verticals first if the mean is distributed and 
   few state elements are updated.
 - How many observations are being assimilated, e.g. if you have a large number of observations, then converting
   all observation verticals first may be more efficient as the conversion is done in parallel.

--- a/guide/vertical-conversion.rst
+++ b/guide/vertical-conversion.rst
@@ -70,12 +70,31 @@ the entire state.
 Choice of when conversion is done 
 ---------------------------------
 
-During the assimilation phase of filter there are two options for when vertical
-conversion is done: all at the start, or on demand.  If the observations to be
-assimilated are expected to impact all or almost all of the state, doing all
-vertical conversion at the start is more efficient. If the observations are
-expected to impact only a small percentage of the state variables then doing it
-on demand is more efficient.
+During assimilation there is a choice for when vertical
+conversion is done: all at the start, before the sequential assimilation loop;
+or on demand, as each observation is processed. 
 
-The options here are namelist selectable at runtime and the impact on total
-runtime can be easily measured and compared.
+The default behavior is to convert all observation locations before the sequential
+assimilation loop, and convert all model state locations on demand. 
+The default setting for vertical conversion in assim_tools_nml:
+
+.. code-block:: text
+
+    &assim_tools_nml
+       convert_all_obs_verticals_first   = .true.,
+       convert_all_state_verticals_first = .false.,
+    /
+
+When deciding to when to convert verticals, consider the following:
+
+- How many state elements are updated, e.g. if you have a large :ref:`cuttoff <localization>`
+  and most of the state is being updated  during assimilation, then converting all state verticals first 
+  may be more efficient.
+- If you are :ref:`distributing the mean <data-distribution>` across MPI processes this will increase the cost of
+  of each conversion. You many not want to convert all state verticals first if the mean is distributed and 
+  few state elements are updated.
+- How many observations are being assimilated, e.g. if you have a large number of observations, then converting
+  all observation verticals first may be more efficient as the conversion is done in parallel.
+
+Before doing large scale experiments, we recommend profiling the assimilation to determine the best setting 
+for your model and assimilation setup.


### PR DESCRIPTION
## Description:
<!--- Describe your changes -->
I have added the specific namelist options for data management in dart, when the "whole" state vector is required
and what the namelist options do. 

I have added the specific namelist options for when vertical conversion is done, what the defaults are set to and why.

I removed some very out-of-date routines ({read|write}_ensemble_restart) from the ensemble manager documentation and removed references to the prepare_vars etc that was removed in #637.

### Fixes issue
<!--- link to github issue(s) -->

fixes #879
fixes #882
fixes #881

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.

### Tests
Built the documentation locally, read it, clicked the links between pages. 

## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [ ] No dataset needed
