### PR TITLE
set ieee for cce compiler in mkmf.tempate

### DIFF
--- a/build_templates/mkmf.template.cce
+++ b/build_templates/mkmf.template.cce
@@ -18,6 +18,6 @@ LD = ftn
 
 INCS = -I$(NETCDF)/include
 LIBS = -L$(NETCDF)/lib -lnetcdff -lnetcdf
-FFLAGS  = -O2  $(INCS)
+FFLAGS  = -O2 -hfp0 $(INCS)
 LDFLAGS = $(FFLAGS) $(LIBS)
 


### PR DESCRIPTION
## Description:
<!--- Describe your changes -->

Setting cce to follow ieee. fpn1 fixes #871, but setting fpn0 since we have had other compilers hit ieee problems (see #557).  See https://github.com/NCAR/DART/issues/871#issuecomment-2956602017 for ieee reproducer.

From cray compiler docs https://cpe.ext.hpe.com/docs/24.11/getting_started/CPE-CCE-Fortran.html 

 fpn[=[no]approx]
Controls the level of floating point optimizations, where n is a value between 0 and 4, with 0 giving the compiler minimum freedom to optimize floating point operations and 4  giving it maximum freedom. The higher the level, the less the floating point values conform to the IEEE standard. 


### Fixes issue
<!--- link to github issue(s) -->
fixes #871 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

### Tests
Please describe any tests you ran to verify your changes.
Ran developer tests for normal distribution

## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [ ] No dataset needed
