### PR TITLE
bug-fix: perfect_model_obs prints

### DIFF
--- a/assimilation_code/programs/perfect_model_obs/perfect_model_obs.f90
+++ b/assimilation_code/programs/perfect_model_obs/perfect_model_obs.f90
@@ -449,8 +449,10 @@ AdvanceTime: do
    write(msgstring, '(A,I7)') 'Number of observations to be evaluated', &
       num_obs_in_set
    call trace_message(msgstring)
-   call print_obs_time(seq, key_bounds(1), 'Time of first observation in window')
-   call print_obs_time(seq, key_bounds(2), 'Time of last  observation in window')
+   if(my_task_id() == 0) then
+      call print_obs_time(seq, key_bounds(1), 'Time of first observation in window')
+      call print_obs_time(seq, key_bounds(2), 'Time of last  observation in window')
+   endif
 
    ! for multi-core runs, each core needs to store the forward operator and the qc value
    call init_ensemble_manager(fwd_op_ens_handle, ens_size, int(num_obs_in_set,i8), 1, transpose_type_in = 2)

--- a/assimilation_code/programs/perfect_model_obs/perfect_model_obs.f90
+++ b/assimilation_code/programs/perfect_model_obs/perfect_model_obs.f90
@@ -9,7 +9,7 @@ program perfect_model_obs
 use        types_mod,     only : r8, i8, metadatalength, MAX_NUM_DOMS
 use    utilities_mod,     only : error_handler, &
                                  find_namelist_in_file, check_namelist_read, &
-                                 E_ERR, E_MSG, E_DBG, nmlfileunit, timestamp, &
+                                 E_ERR, E_MSG, E_ALLMSG, E_DBG, nmlfileunit, timestamp, &
                                  do_nml_file, do_nml_term, logfileunit, &
                                  open_file, close_file
 use time_manager_mod,     only : time_type, get_time, set_time, operator(/=), print_time,   &
@@ -485,6 +485,8 @@ AdvanceTime: do
    ! Compute the forward observation operator for each observation in set
    do j = 1, fwd_op_ens_handle%my_num_vars
 
+      global_obs_num = fwd_op_ens_handle%my_vars(j)
+
       ! Some compilers do not like mod by 0, so test first.
       if (print_every_nth_obs > 0) nth_obs = mod(j, print_every_nth_obs)
 
@@ -492,15 +494,20 @@ AdvanceTime: do
       ! to indicate progress is being made and to allow estimates
       ! of how long the assim will take.
       if (nth_obs == 0) then
-         write(msgstring, '(A,1x,I8,1x,A,I8)') 'Processing observation ', j, &
-                                            ' of ', num_obs_in_set
-         call trace_message(msgstring, 'perfect_model_obs:', -1)
+         if(task_count() == 1) then
+            write(msgstring, '(A,1x,I8,1x,A,I8)') 'Processing observation ', j, &
+                                         ' of ', num_obs_in_set
+            call trace_message(msgstring, 'perfect_model_obs:', -1)
+         else
+            write(msgstring, '(A,1x,I8,1x,A,I8)') 'Processing observation ', global_obs_num, &
+                                         ' of ', num_obs_in_set
+            call error_handler(E_ALLMSG, 'perfect_model_obs:' ,trim(msgstring))
+         endif
          ! or if you want timestamps:
          !     call timestamp(msgstring, pos="debug")
       endif
-      
+
       ! Compute the observations from the state
-      global_obs_num = fwd_op_ens_handle%my_vars(j)
       call get_expected_obs_distrib_state(seq, keys(global_obs_num:global_obs_num), &
          curr_ens_time, .true., &
          istatus, assimilate_this_ob, evaluate_this_ob, &

--- a/assimilation_code/programs/perfect_model_obs/perfect_model_obs.f90
+++ b/assimilation_code/programs/perfect_model_obs/perfect_model_obs.f90
@@ -494,15 +494,9 @@ AdvanceTime: do
       ! to indicate progress is being made and to allow estimates
       ! of how long the assim will take.
       if (nth_obs == 0) then
-         if(task_count() == 1) then
-            write(msgstring, '(A,1x,I8,1x,A,I8)') 'Processing observation ', j, &
-                                         ' of ', num_obs_in_set
-            call trace_message(msgstring, 'perfect_model_obs:', -1)
-         else
-            write(msgstring, '(A,1x,I8,1x,A,I8)') 'Processing observation ', global_obs_num, &
-                                         ' of ', num_obs_in_set
-            call error_handler(E_ALLMSG, 'perfect_model_obs:' ,trim(msgstring))
-         endif
+         write(msgstring, '(A,1x,I8,1x,A,I8)') 'Processing observation ', global_obs_num, &
+                                      ' of ', num_obs_in_set
+         call error_handler(E_ALLMSG, 'perfect_model_obs:' ,trim(msgstring))
          ! or if you want timestamps:
          !     call timestamp(msgstring, pos="debug")
       endif


### PR DESCRIPTION
## Description:

1) Adds a conditional to the print statements in pmo "Processing observation         X  of        Y" so that the error_handler is called with E_ALLMSG if pmo is being run on more than 1 mpi proc

This fixes the issue that was occurring where it was only printing the the obs on task 0, which made it appear that only those obs were being processed

2) Also adds a conditional to only call print_obs_time if on task 0, fixing the issue of it printing the same thing on every task

NOTE that now that we are not using trace_message, these prints will NO LONGER be executed if the namelist option silence is set to true

### Fixes issue
fixes #905 
fixes #922  

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

### Tests
Please describe any tests you ran to verify your changes.

Ran pmo for lorenz models and MOM6 with various numbers of MPI procs and values for print_every_nth_obs, ensured prints were correct

## Checklist for merging

- [ ] Updated changelog entry
- [x] Documentation updated
- [ ] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [x] No dataset needed
