### PR TITLE
Changes to WOD fortran files to be compatible with WOD23 ascii files

### DIFF
--- a/observations/obs_converters/WOD/wod_read_routines.f90
+++ b/observations/obs_converters/WOD/wod_read_routines.f90
@@ -1,5 +1,5 @@
 ! This code is not protected by the DART copyright agreement.
-! DART $Id$
+! DART $Id: wod_read_routines.f90 6256 2013-06-12 16:19:10Z thoar $
 
      module WOD_read_routines_mod      
 
@@ -109,7 +109,7 @@ private
       
         subroutine WODreadDART(nf,iyear,month,iday, &              
                           time,rlat,rlon,levels,istdlev,nvar,ip2,nsecond, &
-                          bmiss,castid,ieof)
+                          bmiss,castid,ieof,iVERSflag)
 
 !     This subroutine reads in the WOD ASCII format and loads it
 !     into arrays which are common/shared with the calling program.
@@ -205,6 +205,7 @@ private
 !******************************************************************
       integer :: nf,iyear,month,iday,levels,istdlev,nvar,ip2(0:maxlevel)
       integer :: nsecond, ieof
+      integer :: iVERSflag
       real    :: time,rlat,rlon,bmiss
 
       
@@ -325,16 +326,16 @@ private
       if ( xchar(1:1) .ne. 'B' .and. xchar(1:1) .ne. 'A' .and. &
            xchar(1:1) .ne. 'C' ) then
 
-         !iVERSflag = 1 !- not WOD-2005 format, must be WOD-1998
+         iVERSflag = 1 !- not WOD-2005 format, must be WOD-1998
          write(6, *) 'file not in WOD-2005 format; cannot be read'
          stop
          !return
 
       else
          if ( xchar(1:1) .eq. 'C' ) then
-          !iVERSflag=2   !- WOD-2013 format
+          iVERSflag=2   !- WOD-2013 format
          else
-          !iVERSflag = 0 !- WOD-2005 format
+          iVERSflag = 0 !- WOD-2005 format
          endif
       endif
       
@@ -486,9 +487,9 @@ private
 !     
 !*****************************************************************
 
-      call charout(istartc,isig(1),iprec(1),itotfig(3),ichar, &
+      call charout(istartc,isig(1),iprec(1),itotfig(1),ichar, &
                   rlat,bmiss)
-      call charout(istartc,isig(2),iprec(2),itotfig(3),ichar, &
+      call charout(istartc,isig(2),iprec(2),itotfig(1),ichar, &
                   rlon,bmiss)
 
 !print *, '2.'
@@ -778,7 +779,7 @@ private
 
       do 50 n = 1,levels
 
-       if ( istdlev.eq.0 ) then
+       if ( istdlev.eq.0 .or. iVERSflag .eq. 2 ) then
 
         call charout(istartc,idsig(n),idprec(n),idtot(n),ichar, &
                      depth(n),bmiss)
@@ -807,7 +808,7 @@ private
        else
     
          iderror(n,ip2(i))=0
-         iorigflag(n,ip2(1))=0
+         iorigflag(n,ip2(i))=0
          msig(n,ip2(i))=0
          mprec(n,ip2(i))=0
          mtot(n,ip2(i))=0
@@ -938,7 +939,7 @@ private
       end module WOD_read_routines_mod      
 
 ! <next few lines under version control, do not edit>
-! $URL$
-! $Id$
-! $Revision$
-! $Date$
+! $URL: https://svn-dares-dart.cgd.ucar.edu/DART/releases/Manhattan/observations/obs_converters/WOD/wod_read_routines.f90 $
+! $Id: wod_read_routines.f90 6256 2013-06-12 16:19:10Z thoar $
+! $Revision: 6256 $
+! $Date: 2013-06-12 10:19:10 -0600 (Wed, 12 Jun 2013) $

--- a/observations/obs_converters/WOD/wod_to_obs.f90
+++ b/observations/obs_converters/WOD/wod_to_obs.f90
@@ -2,7 +2,7 @@
 ! by UCAR, "as is", without charge, subject to all terms of use at
 ! http://www.image.ucar.edu/DAReS/DART/DART_download
 !
-! $Id$
+! $Id: wod_to_obs.f90 11243 2017-03-08 21:35:09Z nancy@ucar.edu $
 
 program wod_to_obs
 
@@ -23,7 +23,7 @@ use time_manager_mod, only : time_type, set_calendar_type, GREGORIAN, set_time,&
 use    utilities_mod, only : initialize_utilities, find_namelist_in_file,    &
                              check_namelist_read, nmlfileunit, do_output,    &
                              get_next_filename, error_handler, E_ERR, E_MSG, &
-                             find_textfile_dims, finalize_utilities,         &
+                             find_textfile_dims, finalize_utilities, &
                              open_file, close_file
 use     location_mod, only : VERTISHEIGHT, set_location
 use obs_sequence_mod, only : obs_sequence_type, obs_type, read_obs_seq,       &
@@ -90,9 +90,9 @@ implicit none
 
 ! version controlled file description for error handling, do not edit
 character(len=256), parameter :: source   = &
-   "$URL$"
-character(len=32 ), parameter :: revision = "$Revision$"
-character(len=128), parameter :: revdate  = "$Date$"
+   "$URL: https://svn-dares-dart.cgd.ucar.edu/DART/releases/Manhattan/observations/obs_converters/WOD/wod_to_obs.f90 $"
+character(len=32 ), parameter :: revision = "$Revision: 11243 $"
+character(len=128), parameter :: revdate  = "$Date: 2017-03-08 14:35:09 -0700 (Wed, 08 Mar 2017) $"
 
 
 integer, parameter ::   num_copies = 1,   &   ! number of copies in sequence
@@ -103,7 +103,7 @@ integer :: j, k, nfiles, num_new_obs, castid, l
 integer :: oday, osec                   
 integer :: obsyear, obsmonth, obsday, obssec
 integer :: obs_num, io, iunit, filenum, dummy
-integer :: funit, levels, istdlev, nvar, nsecond, ieof
+integer :: funit, levels, istdlev, nvar, nsecond, ieof, iVERSflag
 integer :: ip2(0:maxlevel), cast, itype
 logical :: file_exist, did_obs, from_list = .false.
 logical :: have_temp, have_salt
@@ -266,7 +266,7 @@ print *, 'opening file ', trim(next_infile)
    castloop: do    ! until out of data
    call WODreadDART(funit,obsyear,obsmonth,obsday, &
               dtime,lato,lono,levels,istdlev,nvar,ip2,nsecond, &
-              bmiss,castid,ieof)
+              bmiss,castid,ieof,iVERSflag)
 
 !if (ieof /= 0) print *, 'ieof is ', ieof
 
@@ -718,7 +718,7 @@ end function date_ok
 end program wod_to_obs
 
 ! <next few lines under version control, do not edit>
-! $URL$
-! $Id$
-! $Revision$
-! $Date$
+! $URL: https://svn-dares-dart.cgd.ucar.edu/DART/releases/Manhattan/observations/obs_converters/WOD/wod_to_obs.f90 $
+! $Id: wod_to_obs.f90 11243 2017-03-08 21:35:09Z nancy@ucar.edu $
+! $Revision: 11243 $
+! $Date: 2017-03-08 14:35:09 -0700 (Wed, 08 Mar 2017) $


### PR DESCRIPTION
## Description:
<!--- Describe your changes -->
Changes to two fortran files in order for the WOD23 and WOD18 ascii files to be correctly read in

### Fixes issue
https://github.com/NCAR/DART/issues/939

### Types of changes
The changes were made by copying Fred Castruccio's WOD fortran files 1) wod_read_routines.f90 and 2) wod_to_obs.f90. The original files can be found on derecho at /glade/u/home/fredc/DART/Manhattan/observations/obs_converters/WOD

### Tests
I have yearly WOD obs sequence output files for 2012-2017 that have reasonable values by inspection. 

## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [ ] No dataset needed
