### PR TITLE
doc: change link to doi for pop initial ensemble

### DIFF
--- a/models/POP/readme.rst
+++ b/models/POP/readme.rst
@@ -86,7 +86,7 @@ To use DART and CESM POP2 on NSF NCAR's supercomputer, you will need to complete
 the following steps.
 
 #. Download an intial ensemble of POP2 restart files from the `NSF NCAR Geoscience
-   Data Exchange <https://gdex.ucar.edu/dataset/483.html>`_
+   Data Exchange <https://doi.org/10.5065/k8ry-pk58>`_
 #. Configure the scripts for your specific experiment by editing
    ``DART_params.csh``.
 #. Run the appropriate DART setup script to create and build the CESM case.
@@ -222,7 +222,7 @@ initial ensemble.
 
 You can access a collection of POP restart files from Who Kim's multi-century
 ``g210.G_JRA.v14.gx1v7.01`` experiment to serve as an initial ensemble in the
-`NSF NCAR Geoscience Data Exchange <https://gdex.ucar.edu/dataset/483.html>`_. This
+`NSF NCAR Geoscience Data Exchange <https://doi.org/10.5065/k8ry-pk58>`_. This
 experiment uses the JRA-55 dataset for atmospheric forcing (Tsujino et al. 2018 [4]_).
 
 Observation sequence files


### PR DESCRIPTION
## Description:
<!--- Describe your changes -->
NCAR data services are migrating some GDEX datasets to zenado.
This pull request updates the link in the POP documentation (Eighty Member Ensemble of 1.0° POP and CICE restart files on the CESM gx1v7 grid) to use a DOI rather than the gdex address

Note for kicks, the doi https://doi.org/10.5065/k8ry-pk58 still takes you to 
https://gdex.ucar.edu/dataset/483.html
rather than 
https://zenodo.org/records/15508746 
Assuming at some point on or before Aug 27th 2025 the doi will take you zenodo. 

### Fixes issue
<!--- link to github issue(s) -->
fixes #897

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.

### Tests
Please describe any tests you ran to verify your changes.
Built documentation, clicked links

## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [ ] No dataset needed
