### PR TITLE
fix: int main for gregorian_time.c prorgram

### DIFF
--- a/assimilation_code/modules/utilities/gregorian_time.c
+++ b/assimilation_code/modules/utilities/gregorian_time.c
@@ -37,7 +37,7 @@ void convert(int direction, int *days, int *secs,
 enum err vet_time(int days, int secs);
 enum err vet_date(int year, int month, int day, int hour, int min, int sec);
 
-main(int argc, char **argv)
+int main(int argc, char **argv)
 {
     int days, secs, year, month, day, hour, min, sec;
     enum err error;


### PR DESCRIPTION
## Description:
<!--- Describe your changes -->

Add int to main for  gregorian_time.c program for compilers that enforce ISO C99

### Fixes issue
<!--- link to github issue(s) -->
Fixes #961 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

### Tests
Please describe any tests you ran to verify your changes.
Compiled, ran, checked the return code from a fail and and a success

```
> icx gregorian_time.c 
> ./a.out 123456 40
123456    40 == 1939/01/06 00:00:40
> echo $?
0
> ./a.out -123456 0 
error: days must be non-negative
> echo $?
254
```

## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [ ] No dataset needed
