### PR TITLE
ROMS option to have model_interpolate salinity units in kg/kg (default) or g/kg

### DIFF
--- a/models/ROMS_rutgers/model_mod.f90
+++ b/models/ROMS_rutgers/model_mod.f90
@@ -130,6 +130,7 @@ integer  :: assimilation_period_days     = 1                ! Assimilation windo
 integer  :: assimilation_period_seconds  = 0                ! Assimilation window in secs
 real(r8) :: perturbation_amplitude       = 0.02             ! Perturbation size for generating an ensemble
 integer  :: debug                        = 0                ! Turn up for more debug messages
+logical  :: convert_salinity_to_kgkg     = .true.           ! model_interpolate salinity ouput in kg/kg 
 
 character(len=vtablenamelength) ::                &
           variables(MAX_STATE_VARIABLE_FIELDS_CLAMP) = ' '  ! Table of state variables and associated metadata
@@ -140,7 +141,8 @@ namelist /model_nml/ assimilation_period_days,    &
                      perturbation_amplitude,      &
                      roms_filename,               &
                      debug,                       &
-                     variables
+                     variables,                   &
+                     convert_salinity_to_kgkg
 
 ! Interpolation grid handles 
 type(quad_interp_handle) :: interp_t_grid, &
@@ -352,6 +354,8 @@ integer(i8) :: dartidx               ! Index into the DART state
 logical     :: on_land              
 
 
+real(r8), parameter :: CONCENTRATION_TO_PPT = 1000.0_r8
+
 type(quad_interp_handle) :: interp
 
 if (.not. module_initialized) call static_init_model
@@ -471,6 +475,8 @@ if(qty == QTY_TEMPERATURE) then
   ! Deduce the in-situ temperature values
   expected_obs = sensible_temp(expected_T, expected_S, pdbar) 
 endif
+
+if (convert_salinity_to_kgkg .and. qty == QTY_SALINITY) expected_obs = expected_obs / CONCENTRATION_TO_PPT
 
 istatus = 0
 

--- a/models/ROMS_rutgers/readme.rst
+++ b/models/ROMS_rutgers/readme.rst
@@ -143,6 +143,10 @@ The table below describes the configurable variables in this namelist:
      - `character(len=vtablenamelength), dimension(MAX_STATE_VARIABLES * table_columns)`
      - `' '` 
      - Specifies the list of ROMS variables to be assimilated. The variable table is parsed as flat strings with metadata.
+   * - ``convert_salinity_to_kgkg``
+     - `logical`
+     - `.true.`
+     - If true, module_interpolate salinity output is converted to kg/kg, otherwise PSU (g/g) is used. Be sure to match observation units.
 
 
 Variables Table Format


### PR DESCRIPTION
## Description:
<!--- Describe your changes -->
ROMS option to have model_interpolate salinity units in kg/kg (default) or g/kg
The converters we have in the dart repo: wod, GTSPP, give salinity in kg/kg
I believe this choice of kg/kg for units was for POP.  There is no concept of units in observation sequence files or obs_def which is not ideal, but a larger topic beyond the scope of this pull request. 

The namelist option allows users to use observation sequences generated outside dart (g/kg)

It would be good to get some oceanography input on this because I am not sure if this pull request is the correct thing to do. There seems to be differing references on whether psu (dimensionless) is exactly the same as g/kg
 
I'm following this convention:
https://github.com/NCAR/DART/commit/1ef07d8f3dc861e6c70cd08023a16c0a3376ca03
and using /1000. But maybe this is not correct.

 ### Fixes issue
<!--- link to github issue(s) -->
fixes #1003


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

### Tests
Please describe any tests you ran to verify your changes.
PMO to take a look at interpolated values

## Checklist for merging

- [ ] Updated changelog entry
- [x] Documentation updated
- [ ] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [x] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [ ] No dataset needed
