### PR TITLE
fix:model_size collected in test 0 of model_mod_check , needed for interpolation tests

### DIFF
--- a/assimilation_code/programs/model_mod_check/model_mod_check.f90
+++ b/assimilation_code/programs/model_mod_check/model_mod_check.f90
@@ -155,6 +155,7 @@ call print_test_message('TEST 0', &
 call static_init_assim_model()
 
 num_domains = get_num_domains()
+model_size = get_model_size()
 
 call print_test_message('TEST 0', ending=.true.)
 


### PR DESCRIPTION
## Description:
<!--- Describe your changes -->

model_mod_check interpolate tests need a state so runs test2 to read a state
test2 initializes an ensemble handle so needs the model_size
This pull request adds `get_model_size` to test 0 (test setup) so that model_size is available for use in the tests.

### Fixes issue
<!--- link to github issue(s) -->
fixes #1016

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

### Tests
Please describe any tests you ran to verify your changes.
I ran the model_mod_check test 4

```
&model_mod_check_nml
   run_tests = 4
```


## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [x] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [ ] No dataset needed
