### PR TITLE
Updated download link for the WRF tutorial

### DIFF
--- a/models/wrf/tutorial/README.rst
+++ b/models/wrf/tutorial/README.rst
@@ -255,7 +255,7 @@ bash  ``export BASE_DIR=<path_to_your_working_directory>``
    ::
 
        cd $BASE_DIR
-       wget http://www.image.ucar.edu/wrfdart/tutorial/wrf_dart_tutorial_29Apr2024.tar.gz
+       wget data.dart.ucar.edu/WRF/wrf_dart_tutorial_29Apr2024.tar.gz
        tar -xzvf wrf_dart_tutorial_29Apr2024.tar.gz
 
    After untarring the file you should see the following directories:


### PR DESCRIPTION
## Description:
DART data has been migrated from the old image server `https://www.image.ucar.edu/pub/DART/` to a new domain: `data.dart.ucar.edu`. This PR updates the download link of the WRF tutorial. I only found one place in the README file where the `wget` on the download link is called. I'm happy to do further changes if I missed anything. 

### Fixes issue
NA

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.

### Tests
Please describe any tests you ran to verify your changes.

## Checklist for merging

- [ ] Updated changelog entry
- [x] Documentation updated
- [ ] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [x] No dataset needed
