### PR TITLE
Adding -check nouninit flag to debugging flags in mkmf.tempate.ifx.linux

### DIFF
--- a/build_templates/mkmf.template.ifx.linux
+++ b/build_templates/mkmf.template.ifx.linux
@@ -20,6 +20,9 @@ FFLAGS  = -O -assume buffered_io $(INCS)
 LDFLAGS = $(FFLAGS) $(LIBS)
 
 # for development or debugging, use this instead:
-# FFLAGS = -g -C -check noarg_temp_created -fpe0 \
-#          -fp-model precise  -ftrapuv -traceback \
+# FFLAGS = -g -C -check noarg_temp_created -check nouninit \
+#          -fpe0 -fp-model precise  -ftrapuv -traceback \
 #          -warn declarations,uncalled,unused $(INCS)
+#
+# "-check nouninit" needed for newer versions of ifx, removable
+# if compatible with libc


### PR DESCRIPTION
## Description:
<!--- Describe your changes -->
Please provide a summary of the change and include any relevant motivation and context. 

DART fails to compile with the more recent versions of ifx on Derecho due to a DART-independent error from the Memory Sanitizer in the libc. This error occurs when compiling any program with ifx and the compiler flag "-check uninit", which is done by default when using the debugging flags in the mkmf.template

This PR adds a new debugging flag "-check nouninit" to mkmf.tempate.ifx.linux to get around this compiler based error.

This means that the DART code is not checked for unitialized values when debugging with ifx. This is noted in the mkmf.template

### Fixes issue
#1046 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

### Tests
Please describe any tests you ran to verify your changes.

Compiled and run DART with several models using the latest, default intel-oneapi module (intel-oneapi/2024.2.1)

## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [x] No dataset needed
