### PR TITLE
fix: remove _r8 from .nml files

### DIFF
--- a/models/cam-fv/model_mod.nml
+++ b/models/cam-fv/model_mod.nml
@@ -36,7 +36,7 @@
    suppress_grid_info_in_output        = .false.
    custom_routine_to_generate_ensemble = .true.
    fields_to_perturb                   = ''
-   perturbation_amplitude              = 0.0_r8
+   perturbation_amplitude              = 0.0
    using_chemistry                     = .false.
    use_variable_mean_mass              = .false.
    debug_level                         = 0

--- a/models/cam-se/model_mod.nml
+++ b/models/cam-se/model_mod.nml
@@ -46,7 +46,7 @@
    suppress_grid_info_in_output    = .false.
    custom_routine_to_generate_ensemble = .true.
    fields_to_perturb               = ""
-   perturbation_amplitude          = 0.0_r8
+   perturbation_amplitude          = 0.0
    using_chemistry                 = .false.
    no_normalization_of_scale_heights = .true.
 /

--- a/models/null_model/model_mod.nml
+++ b/models/null_model/model_mod.nml
@@ -3,7 +3,7 @@
    delta_t              = 0.05,
    time_step_days       = 0,
    time_step_seconds    = 3600  
-   noise_amplitude      = 0.0_r8
+   noise_amplitude      = 0.0
    advance_method       = 'simple'
    interpolation_method = 'standard'
 /


### PR DESCRIPTION
## Description:
<!--- Describe your changes -->
This pull request removes the _r8 from .nml files
This _r8 causes errors in namelist reads when reading values (e.g. 0.0_r8)

### Fixes issue
<!--- link to github issue(s) -->
fixes #1055

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

### Tests
Please describe any tests you ran to verify your changes.
See #1055 namelist read code example. 
Searched for *.nml files with _r8 (and _r8, _digits13, i8, i4)

## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [ ] No dataset needed
