### PR TITLE
Route model_mod calls for DART programs though assim_model_mod

### DIFF
--- a/assimilation_code/modules/assimilation/assim_model_mod.f90
+++ b/assimilation_code/modules/assimilation/assim_model_mod.f90
@@ -26,7 +26,8 @@ use     model_mod, only : get_model_size, static_init_model, get_state_meta_data
                           pert_model_copies, get_close_obs, get_close_state,       &
                           convert_vertical_obs, convert_vertical_state,            &
                           interpolate => model_interpolate,                        &
-                          read_model_time, write_model_time
+                          read_model_time, write_model_time, &
+                          nc_write_model_atts
 
 implicit none
 private
@@ -46,7 +47,8 @@ public :: static_init_assim_model, &
           convert_vertical_obs, &
           convert_vertical_state, &
           read_model_time, &
-          write_model_time
+          write_model_time, &
+          nc_write_model_atts
 
 ! Ensure init code is called exactly once
 logical :: module_initialized = .false.

--- a/assimilation_code/modules/io/direct_netcdf_mod.f90
+++ b/assimilation_code/modules/io/direct_netcdf_mod.f90
@@ -102,13 +102,10 @@ use io_filenames_mod,     only : get_restart_filename, inherit_copy_units, &
                                  netcdf_file_type, READ_COPY, WRITE_COPY, &
                                  noutput_state_variables
 
-use assim_model_mod,      only : get_model_size, read_model_time, write_model_time
-
-!>@todo FIXME : should move to assim_model_mod.f90
-use model_mod,            only : nc_write_model_atts
+use assim_model_mod,      only : get_model_size, read_model_time, write_model_time, &
+                                 nc_write_model_atts
 
 use typesizes
-
 use netcdf
 
 implicit none

--- a/assimilation_code/modules/io/state_vector_io_mod.f90
+++ b/assimilation_code/modules/io/state_vector_io_mod.f90
@@ -61,8 +61,7 @@ use io_filenames_mod,     only : get_restart_filename, file_info_type, &
                                  assert_restart_names_initialized, &
                                  single_file_initialized
 
-!>@todo FIXME This should go through assim_model_mod
-use model_mod,            only : read_model_time
+use assim_model_mod,            only : read_model_time
 
 use state_structure_mod,  only : get_num_domains
 

--- a/assimilation_code/programs/create_fixed_network_seq/create_fixed_network_seq.f90
+++ b/assimilation_code/programs/create_fixed_network_seq/create_fixed_network_seq.f90
@@ -16,7 +16,7 @@ use obs_sequence_mod, only : obs_sequence_type, obs_type, read_obs_seq, &
                              get_copy_meta_data, get_qc_meta_data, set_qc_meta_data
 use time_manager_mod, only : time_type, set_time, interactive_time, &
                              operator(*), operator(+)
-use        model_mod, only : static_init_model
+use  assim_model_mod, only : static_init_assim_model
 
 implicit none
 
@@ -34,7 +34,7 @@ integer                 :: seconds, days, i, j, network_size, option, num_times,
 call initialize_utilities('Create_fixed_network_seq')
 
 ! Call the underlying model's static initialization for calendar info
-call static_init_model()
+call static_init_assim_model()
 
 ! Initialize the obs_sequence module
 call static_init_obs_sequence

--- a/assimilation_code/programs/fill_inflation_restart/fill_inflation_restart.f90
+++ b/assimilation_code/programs/fill_inflation_restart/fill_inflation_restart.f90
@@ -36,7 +36,7 @@ use      io_filenames_mod, only : io_filenames_init, file_info_type,       &
                                   get_restart_filename, set_file_metadata, &
                                   set_io_copy_flag, READ_COPY, WRITE_COPY
 
-use             model_mod, only : get_model_size
+use       assim_model_mod, only : get_model_size
 
 use     mpi_utilities_mod, only : initialize_mpi_utilities, finalize_mpi_utilities
 

--- a/assimilation_code/programs/model_mod_check/model_mod_check.f90
+++ b/assimilation_code/programs/model_mod_check/model_mod_check.f90
@@ -23,7 +23,8 @@ use          obs_kind_mod, only : get_name_for_quantity
 
 use      obs_sequence_mod, only : static_init_obs_sequence
 
-use       assim_model_mod, only : static_init_assim_model
+use       assim_model_mod, only : static_init_assim_model, get_model_size, &
+                                  get_state_meta_data
 
 use      time_manager_mod, only : time_type, print_time, print_date, operator(-), &
                                   get_calendar_type, NO_CALENDAR
@@ -41,8 +42,6 @@ use      io_filenames_mod, only : io_filenames_init, file_info_type,       &
                                   set_io_copy_flag, READ_COPY, WRITE_COPY
 
 use distributed_state_mod, only : create_state_window, free_state_window
-
-use             model_mod, only : get_model_size, get_state_meta_data
 
 use  test_interpolate_mod, only : test_interpolate_single, &
                                   test_interpolate_range, &

--- a/models/model_mod_tools/model_check_utilities_mod.f90
+++ b/models/model_mod_tools/model_check_utilities_mod.f90
@@ -24,9 +24,9 @@ use          obs_kind_mod, only : get_name_for_quantity, &
 
 use  ensemble_manager_mod, only : ensemble_type
 
-use             model_mod, only : get_model_size, &
+use       assim_model_mod, only : get_model_size, &
                                   get_state_meta_data, &
-                                  model_interpolate
+                                  interpolate
 
 implicit none
 private
@@ -83,7 +83,7 @@ if ( do_output() ) then
    write(*,'(A)') ''
 endif
 
-call model_interpolate(ens_handle, ens_size, location, quantity_index, interp_vals, ios_out)
+call interpolate(ens_handle, ens_size, location, quantity_index, interp_vals, ios_out)
 
 num_passed = 0
 do imem = 1, ens_size

--- a/models/model_mod_tools/test_interpolate_oned.f90
+++ b/models/model_mod_tools/test_interpolate_oned.f90
@@ -32,9 +32,9 @@ use model_check_utilities_mod, only : test_single_interpolation, &
                                       count_error_codes, &
                                       verify_consistent_istatus
 
-use             model_mod, only : get_model_size, &
+use       assim_model_mod, only : get_model_size, &
                                   get_state_meta_data, &
-                                  model_interpolate
+                                  interpolate
 
 use netcdf
 
@@ -141,7 +141,7 @@ do i = 1, nx
    X(i) = interp_test_xrange(1) + real(i-1,r8) * interp_test_dx
    loc  = set_location(X(i))
 
-   call model_interpolate(ens_handle, ens_size, loc, quantity_index, field(i,:), ios_out)
+   call interpolate(ens_handle, ens_size, loc, quantity_index, field(i,:), ios_out)
 
    call verify_consistent_istatus(ens_size, field(i,:), ios_out)
 

--- a/models/model_mod_tools/test_interpolate_threed_cartesian.f90
+++ b/models/model_mod_tools/test_interpolate_threed_cartesian.f90
@@ -32,9 +32,9 @@ use model_check_utilities_mod, only : test_single_interpolation, &
                                       count_error_codes, &
                                       verify_consistent_istatus
 
-use             model_mod, only : get_model_size, &
+use       assim_model_mod, only : get_model_size, &
                                   get_state_meta_data, &
-                                  model_interpolate
+                                  interpolate
 
 use netcdf
 
@@ -145,7 +145,7 @@ do i = 1, nx
          Z(k) = interp_test_zrange(1) + real(k-1,r8) * interp_test_dz
          loc  = set_location(X(i), Y(j), Z(k))
 
-         call model_interpolate(ens_handle, ens_size, loc, quantity_index, &
+         call interpolate(ens_handle, ens_size, loc, quantity_index, &
                                 field(i,j,k,:), ios_out)
 
          call verify_consistent_istatus(ens_size, field(i,j,k,:), ios_out)

--- a/models/model_mod_tools/test_interpolate_threed_sphere.f90
+++ b/models/model_mod_tools/test_interpolate_threed_sphere.f90
@@ -34,9 +34,9 @@ use model_check_utilities_mod, only : test_single_interpolation, &
                                       count_error_codes, &
                                       verify_consistent_istatus
 
-use             model_mod, only : get_model_size, &
+use       assim_model_mod, only : get_model_size, &
                                   get_state_meta_data, &
-                                  model_interpolate
+                                  interpolate
 
 use netcdf
 
@@ -168,7 +168,7 @@ do ilon = 1, nlon
          vert(kvert) = interp_test_vertrange(1) + real(kvert-1,r8) * interp_test_dvert
          loc = set_location(lon(ilon), lat(jlat), vert(kvert), vertcoord)
 
-         call model_interpolate(ens_handle, ens_size, loc, quantity_index, &
+         call interpolate(ens_handle, ens_size, loc, quantity_index, &
                                 field(ilon,jlat,kvert,:), ios_out)
 
          call verify_consistent_istatus(ens_size, field(ilon,jlat,kvert,:), ios_out)

--- a/models/model_mod_tools/test_interpolate_twod.f90
+++ b/models/model_mod_tools/test_interpolate_twod.f90
@@ -32,9 +32,9 @@ use model_check_utilities_mod, only : test_single_interpolation, &
                                       count_error_codes, &
                                       verify_consistent_istatus
 
-use             model_mod, only : get_model_size, &
+use       assim_model_mod, only : get_model_size, &
                                   get_state_meta_data, &
-                                  model_interpolate
+                                  interpolate
 
 use netcdf
 
@@ -145,7 +145,7 @@ do i = 1, nx
       Y(j) = interp_test_yrange(1) + real(j-1,r8) * interp_test_dy
       loc  = set_location(X(i), Y(j))
 
-      call model_interpolate(ens_handle, ens_size, loc, quantity_index, field(i,j,:), ios_out)
+      call interpolate(ens_handle, ens_size, loc, quantity_index, field(i,j,:), ios_out)
 
       call verify_consistent_istatus(ens_size, field(i,j,:), ios_out)
 


### PR DESCRIPTION
## Description:
<!--- Describe your changes -->
This pull request routes model_mod calls for DART programs though assim_model_mod. 
model_mod_check was partially using assim_model_mod, and partially directly calling model_mod which 
did not allow you to create a custom intercept layer using assim_model_mod (e.g having multiple model_mods).

Changes: call assim_model_mod rather than model_mod directly for dart programs
* Public model_mod routines through assim_mod_mod
* model_mod_check use assim_mod_mod::interpolate

FIXMES fixed:
* nc_write_model_atts was not going though assim_model_mod
* read_model_time in direct_netcdf_mod was not going though assim_model_mod

Left alone model specific programs, i.e. those in models directory and the two obs converters that use model info:
* create_identity_stream_flow_obs (models/wrf_hydro)
* convert_roms_obs (obs_converters/ROMS)
 
This is because the model specific code is making assumptions about the state, e.g. the identity obs, state indexing.
And I think programs in the models/MODEL directory are assuming they are not using the intercept layer. 

### Fixes issue
<!--- link to github issue(s) -->
fixes #1056

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
   I'm putting bug fix since there are FIXMEs about this
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update


### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

### Tests
Please describe any tests you ran to verify your changes.
run_all_quickdbuild.sh 

For searching for occurrences:
 
* `ripgrep -i -e 'use\s*model_mod\s*,\s*only'`
* Excluding models directory: `ripgrep -i -e 'use\s*model_mod\s*,\s*only' --glob '!models/*'`

Note obs_timejitter.f90 is one of the programs that is never routinely compiled #1068, I will add quickdbuild.sh to exercise these program builds. 

## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [ ] No dataset needed
