### PR TITLE
Adding debug flags for cce compiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.mod
 *.o
 *.swp
+*.lst
 *__pycache__*
 *obscount.txt
 *region?.ps

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,20 @@ individual files.
 
 The changes are now listed with the most recent at the top.
 
+**March 23 2026 :: CCE compiler flags. Tag v11.21.2**
+
+- Updated mkmf.template for CCE compiler 
+- Default qtys updated with land qtys
+
+Documentation updates:
+
+  - Removed duplicate list of observation converters
+  - Anchors for observation converter docs
+
+Bug-fix:
+
+  - Removed _r8 from .nml files
+
 **March 6 2026 :: MOM6 clamping. Tag v11.21.1**
 
 MOM6:

--- a/build_templates/mkmf.template.cce
+++ b/build_templates/mkmf.template.cce
@@ -18,8 +18,8 @@ LD = ftn
 
 INCS = -I$(NETCDF)/include
 LIBS = -L$(NETCDF)/lib -lnetcdff -lnetcdf
-#FFLAGS  = -O2 -hfp0 $(INCS)
+FFLAGS  = -O2 -hfp0 $(INCS)
 LDFLAGS = $(FFLAGS) $(LIBS)
 
 # For development or debugging, use the following flags.
-FFLAGS  = -g -O0 -m2 -rl -Rbcdsp -Ktrap=inv,divz,ovf,unf -hbounds $(INCS)
+# FFLAGS  = -g -O0 -m2 -rl -Rbcdsp -Ktrap=inv,divz,ovf -hbounds $(INCS)

--- a/build_templates/mkmf.template.cce
+++ b/build_templates/mkmf.template.cce
@@ -21,3 +21,5 @@ LIBS = -L$(NETCDF)/lib -lnetcdff -lnetcdf
 FFLAGS  = -O2 -hfp0 $(INCS)
 LDFLAGS = $(FFLAGS) $(LIBS)
 
+# For development or debugging, use the following flags.
+# FFLAGS  = -g -O0 -m2 -rl -Rbcdsp -Ktrap=inv,divz,ovf,unf -hbounds -hfp0 $(INCS)

--- a/build_templates/mkmf.template.cce
+++ b/build_templates/mkmf.template.cce
@@ -18,8 +18,8 @@ LD = ftn
 
 INCS = -I$(NETCDF)/include
 LIBS = -L$(NETCDF)/lib -lnetcdff -lnetcdf
-FFLAGS  = -O2 -hfp0 $(INCS)
+#FFLAGS  = -O2 -hfp0 $(INCS)
 LDFLAGS = $(FFLAGS) $(LIBS)
 
 # For development or debugging, use the following flags.
-# FFLAGS  = -g -O0 -m2 -rl -Rbcdsp -Ktrap=inv,divz,ovf,unf -hbounds -hfp0 $(INCS)
+FFLAGS  = -g -O0 -m2 -rl -Rbcdsp -Ktrap=inv,divz,ovf,unf -hbounds $(INCS)

--- a/conf.py
+++ b/conf.py
@@ -21,7 +21,7 @@ copyright = '2023, University Corporation for Atmospheric Research'
 author = 'Data Assimilation Research Section'
 
 # The full version, including alpha/beta/rc tags
-release = '11.21.1'
+release = '11.21.2'
 root_doc = 'index'
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
## Description:

Adds debugging flags to the mkmf.template.cce

Includes the following flags:

-g
When specified the debug level is determined by the optimization level. If specified with no optimization level -O, the default is optimized debugging.


-O0
Disables all optimizations including floating point optimizations

Note that by selecting this optimization level, it automatically specifies the -hfp0 flag, which:
Controls the level of floating point optimizations, where n is a value between 0 and 4, with 0 giving the compiler minimum freedom to optimize floating point operations and 4 giving it maximum freedom. The higher the level, the less the floating point values conform to the IEEE standard. 

-m2 
Specifies the minimum compiler message levels to enable.
The -m messages levels are as follows:
0: Error, Warning, Caution, Note, and Comment
1: Error, Warning, Caution, and Note
2: Error, Warning, and Caution
3: Error and Warning (default)
4: Error


-rl 
Lists source code and includes lint style checking. The listing includes the COMMON block report (see the -rc option for more information about the COMMON block report).


-Rbcdsp 
Specifies any of a group of runtime checks for your program. 
b: Enables checking of array bounds. Bounds checking is not performed on arrays dimensioned as (1). 
c: Enables conformance checking of array operands in array expressions.
d: Enables a run time check for the !dir$ collapse directive and checks the validity of the loop_info count information.
p: Generates run time code to check the association or allocation status of referenced POINTER variables, ALLOCATABLE arrays, or assumed-shape arrays.
s: Enables checking of character substring bounds.


-Ktrap=inv,divz,ovf,unf
Enable traps for the specified exceptions.
Here, I’ve selected to use the following options:
inv: Trap on invalid operation.
divz: Trap on divide-by-zero.
ovf: Trap on overflow (i.e. the result of an operation is too large to be represented).
unf: Trap on underflow (i.e. the result of an operation is too small to be represented). I noticed that the unf option was not used in the gfortran mkmf.template - **should it stay in here?**


-hbounds
Enables checking of array bounds.

### Fixes issue
fixes #1059 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

### Tests
Built lorenz_96 and ran filter, with the full set of debugging flags listed

## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [x] No dataset needed
