### PR TITLE
fix: buildpreprocess use -e to check if a path exists rather than -d for "has to be a directory" for .git

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,21 @@ individual files.
 
 The changes are now listed with the most recent at the top.
 
+**May 15 2026 :: CIRRUS GitHub actions. Tag v11.23.1**
+
+New Repo Infrastructure:
+
+ - CIRRUS NCAR cloud GitHub actions for various compilers
+
+Bug fixes:
+
+ - Build functions fix for DART as a submodule
+ - Outstanding model_mod calls routed through assim_model_mod
+
+Documentation update:
+
+ - Identity observations documentation
+
 **April 29 2026 :: Quad Utilities Enhanced Stability & ROMS Memory Improvements. Tag v11.23.0**
 
  - Improved numerical robustness of quadrilateral interpolation in quad_utils_mod

--- a/build_templates/buildpreprocess.sh
+++ b/build_templates/buildpreprocess.sh
@@ -15,7 +15,7 @@ function dartversion() {
 
 local git_version
 
-if command -v git >/dev/null 2>&1 && [ -d "$DART/.git" ]; then
+if command -v git >/dev/null 2>&1 && [ -e "$DART/.git" ]; then
     git_version=$(cd "$DART" && git describe --tags --dirty --always 2>/dev/null || echo "version_unknown")
 else
     git_version="version_unknown"

--- a/conf.py
+++ b/conf.py
@@ -21,7 +21,7 @@ copyright = '2023, University Corporation for Atmospheric Research'
 author = 'Data Assimilation Research Section'
 
 # The full version, including alpha/beta/rc tags
-release = '11.23.0'
+release = '11.23.1'
 root_doc = 'index'
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
## Description:
<!--- Describe your changes -->

When detecting the DART version buildpreprocess is checking for the .git directory.  If you have checked out dart as a git submodule, .git is not a directory so the git version is left unset. 

.git is a file if you have DART as a git submodule

Use -e to check if a path exists rather than -d for "has to be a directory" for .git
Can be a file, can be directory. 

Currently DART_interface for DART as a CESM component is using DART as a submodule, but there may be other use cases where people want to have DART as a submodule.

### Fixes issue
<!--- link to github issue(s) -->
fixes #1103

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

### Tests
Please describe any tests you ran to verify your changes.

Build and run preprocess + filter with DART as normal (just `git clone https://github.com/NCAR/DART.git`)
Build and run with DART as a submodule 

 ``` 
 git clone --recurse-submodules https://github.com/CROCODILE-CESM/DART_interface
 cd DART_interface/DART
 git checkout version_submod 
```

  

## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [x] No dataset needed
