### PR TITLE
fix: add dart version to obs converter build functions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,18 @@ individual files.
 
 The changes are now listed with the most recent at the top.
 
+**May 27 2026 :: Copernicus Observation Converters. Tag v11.24.0**
+
+New Features:
+
+  - Copernicus SSH L3 NRT Observation Converter
+  - Copernicus SST L3S Observation Converter
+ 
+Bug fix:
+
+  - DART version in observation converter logs
+
+
 **May 15 2026 :: CIRRUS GitHub actions. Tag v11.23.1**
 
 New Repo Infrastructure:

--- a/build_templates/buildconvfunctions.sh
+++ b/build_templates/buildconvfunctions.sh
@@ -192,7 +192,7 @@ else
   mkmf_libs=""
 fi
  
- $DART/build_templates/mkmf -a $DART -x $m $mkmf_libs -p $(basename $1)  \
+ $DART/build_templates/mkmf -c $version_def -a $DART -x $m $mkmf_libs -p $(basename $1)  \
      $EXTRA \
      $convsrc \
      $program \

--- a/conf.py
+++ b/conf.py
@@ -21,7 +21,7 @@ copyright = '2023, University Corporation for Atmospheric Research'
 author = 'Data Assimilation Research Section'
 
 # The full version, including alpha/beta/rc tags
-release = '11.23.1'
+release = '11.24.0'
 root_doc = 'index'
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
## Description:
<!--- Describe your changes -->
This pull request adds the dart version to the obs convert build functions.
Following the buildfunctions for models interfaces  (#983)

### Fixes issue
<!--- link to github issue(s) -->
fixes #1112 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

### Tests
Please describe any tests you ran to verify your changes.
Build and run WOD converter.
Ran all quickbuilds (https://github.com/NCAR/DART/actions/runs/26180325584) to check all converter builds. 

## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [ ] No dataset needed
