### PR TITLE
Read the docs  theme update

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -55,6 +55,7 @@ html_theme_options = {
     'logo_only': True,
     'includehidden': False
 }
+html_use_index = False
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['guide/_templates']

--- a/guide/_static/css/custom.css
+++ b/guide/_static/css/custom.css
@@ -12,7 +12,7 @@
   --light-blue: #42C0FF;
   --orange: #FAA119;
   --yellow: #ffdd31;
-  --search-section-height: 150px; /* Adjust this value to match your search section height */
+  --search-section-height: 500px; /* Adjust this value to match your search section height */
 }
 
 /* Apply Poppins font to text elements (excluding code blocks) */

--- a/guide/requirements.txt
+++ b/guide/requirements.txt
@@ -1,3 +1,3 @@
 Sphinx==6.2.1
-sphinx-rtd-theme==1.2.2
+sphinx-rtd-theme==3.1.0
 sphinx_copybutton


### PR DESCRIPTION
## Description:
<!--- Describe your changes -->
This pull request updates the documentation them to sphinx-rtd-theme==3.1.0
The reason for updating is to use the readthedocs search. 

Note for reviewers, the readthedocs search is only on the web (docs.dart.ucar.edu/version). Local builds will still have the same search as we have now. 

The small downside I have found is that readthedocs doesn't _instantly_ update the search index it builds, but I don't think this is a dealbreaker.

The setting 
 html_use_index = False
is to stop building an index page (D for data assimilation, O for awesome, etc.). We'd been using this to force results to show up in the previous theme's search. We may actually want an index page at some point in the future. 

### Fixes issue
<!--- link to github issue(s) -->
fixes #1106

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update - the sphinx theme

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

### Tests
Please describe any tests you ran to verify your changes.

Local builds, and 
https://docs.dart.ucar.edu/en/rtd-theme-update/index.html

## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [ ] No dataset needed
