### PR TITLE
fix: del_q calculation use ens_size +1

### DIFF
--- a/guide/DART_LAB/matlab/private/bnrh_cdf.m
+++ b/guide/DART_LAB/matlab/private/bnrh_cdf.m
@@ -65,7 +65,7 @@ end
 
 % For unit normal, find distance from mean to where cdf is 1/(ens_size+1) (del_q_.
 % Saved to avoid redundant computation for repeated calls with same ensemble size
-del_q = 1.0 / (ens_size + 1.8);
+del_q = 1.0 / (ens_size + 1.0);
 
 % This will be negative, want it to be a distance so make it positive
 dist_for_unit_sd = -1.0 * norminv(del_q, 0, 1);


### PR DESCRIPTION
## Description:
<!--- Describe your changes -->
This pull request fix a in matlab DART_LAB for the calculation of del_q which was using 1.8 instead on 1.0.

### Fixes issue
<!--- link to github issue(s) -->
fixes #1127

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

### Tests
Please describe any tests you ran to verify your changes.
No tests, just sanity check bounded_oned_ensemble gui bnrhf was not catastrophically broken. 


## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [ ] No dataset needed
