### PR TITLE
edits to compile with ifort on Derecho as of July 2026

### DIFF
--- a/developer_tests/build_everything/run_all_quickbuilds.sh
+++ b/developer_tests/build_everything/run_all_quickbuilds.sh
@@ -58,12 +58,21 @@ fi
 
 # mkmf for chosen compiler
 case $compiler in
-   ifx   ) module load intel-oneapi ;;
-   ifort ) module load intel-classic ;;
+   ifx   ) module load intel ;;
+   ifort ) module load ncarenv/24.12 intel/2024.2.1 hdf5/1.12.3 netcdf/4.9.2 craype/2.7.31 libfabric/1.15.2.0 cray-mpich/8.1.29 ;;
      *   ) module load $compiler ;;
 esac
 
+
 cp build_templates/$mkmf_template build_templates/mkmf.template
+if [[ $compiler == "ifort" ]]; then
+export LD_LIBRARY_PATH="$NETCDF/lib:$NETCDF/lib64${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+cat >> build_templates/mkmf.template <<'EOF'
+NETCDF = /glade/u/apps/derecho/24.12/spack/opt/spack/netcdf/4.9.2/oneapi/2024.2.1/uao5
+INCS = -I$(NCAR_INC_NETCDF)
+LIBS = -L$(NCAR_LDFLAGS_NETCDF) -L$(NCAR_LDFLAGS_NETCDF64) -lnetcdff -lnetcdf
+EOF
+fi
 
 # Build preprocess once
 pp_dir=$DART/assimilation_code/programs/preprocess


### PR DESCRIPTION
## Description:
<!--- Describe your changes -->

edits to compile with ifort on Derecho as of July 2026 for build_everything

The older modules on Derecho appear to be janked up,
I had to set the LD_LIBRARY_PATH and netcdf c and netcdf f libraries in lib64 and lib respectively

I'm not sure whether it is worth having the ifort build in the build_everything since ifort is not supported on Derecho (or by intel). 
But here is the changes need to compile with ifort.  I'm leaning to removing ifort from the list on compilers to build with on Derecho, since I'm not sure how long these old modules will be available. 