### PR TITLE
Mom6 read_model_time 

### DIFF
--- a/models/MOM6/model_mod.f90
+++ b/models/MOM6/model_mod.f90
@@ -12,7 +12,8 @@ module model_mod
 
 use        types_mod, only : r8, i8, MISSING_R8, vtablenamelength
 
-use time_manager_mod, only : time_type, set_time, set_date, set_calendar_type
+use time_manager_mod, only : time_type, set_time, set_date, set_calendar_type, &
+                             get_time
 
 use     location_mod, only : location_type, get_close_type, &
                              loc_get_close_obs => get_close_obs, &
@@ -132,10 +133,18 @@ integer  :: assimilation_period_seconds   = 0
 character(len=vtablenamelength) :: model_state_variables(MAX_STATE_VARIABLE_FIELDS_CLAMP) = ' '
 character(len=NF90_MAX_NAME) :: layer_name = 'Layer'
 logical :: use_pseudo_depth = .false. ! use pseudo depth instead of sum(layer thickness) for vertical location
+! reference date to use instead of "days since 0001-01-01 00:00:00"
+integer :: reference_year = 1 ! reference year
+integer :: reference_month = 1 ! reference month
+integer :: reference_day = 1! reference day
+integer :: reference_hour = 0 ! reference hour
+integer :: reference_minute = 0 ! reference minute
+integer :: reference_second = 0 ! reference second
 
 namelist /model_nml/ template_file, static_file, ocean_geometry, assimilation_period_days, &
                      assimilation_period_seconds, model_state_variables, layer_name, &
-                     use_pseudo_depth
+                     use_pseudo_depth, reference_year, reference_month, reference_day, &
+                     reference_hour, reference_minute, reference_second
 
 
 interface on_land
@@ -1068,9 +1077,12 @@ type(time_type) :: read_model_time
 integer :: ncid
 character(len=*), parameter :: routine = 'read_model_time'
 real(r8) :: days, seconds
+integer :: ref_days, ref_seconds
+type(time_type) :: user_reference_time
 integer :: dart_base_date_in_days, dart_days, dart_seconds
 
-dart_base_date_in_days = 584388 ! 1601 1 1 0 0
+if ( .not. module_initialized ) call static_init_model
+
 ncid = nc_open_file_readonly(filename, routine)
 
 if (nc_variable_exists(ncid, 'Time')) then
@@ -1081,12 +1093,25 @@ endif
 
 call nc_close_file(ncid, routine)
 
-! MOM6 counts days from year 1 as a real number
-! DART counts days from 1601 as integer days integer seconds
-dart_days = floor(days)
-seconds = (days - real(dart_days, r8)) * 86400.0_r8
+! DART counts days from 1601-01-01, MOM6 counts days from 0001-01-01
+! However, user may want a different reference date for MOM6 set from model_nml
+if (reference_year == 1) then
+   ! Convert straight to DART's 1601-01-01 epoch using the fixed calendar offset.
+   dart_base_date_in_days = 584388 ! 1601 1 1 0 0, expressed as days since 0001-01-01
+   dart_days = floor(days) - dart_base_date_in_days
+   seconds = (days - floor(days)) * 86400.0_r8
+else
+   if (reference_year < 1601) then
+      call error_handler(E_ERR, routine, 'reference_year must be >= 1601 to use a year, or 1 to use MOM6 reference date of 0001-01-01')
+   endif
+   ! days from file is days since user supplied reference date.
+   user_reference_time = set_date(reference_year, reference_month, reference_day, &
+                        reference_hour, reference_minute, reference_second)
+   call get_time(user_reference_time, ref_seconds, ref_days) ! ref time in seconds and days since 1601-01-01
+   dart_days = ref_days + floor(days) ! add days read from file to days since 1601-01-01
+   seconds = real(ref_seconds, r8) + (days - floor(days)) * 86400.0_r8
+endif
 
-dart_days = dart_days - dart_base_date_in_days
 dart_seconds = int(seconds)
 
 read_model_time = set_time(dart_seconds,dart_days)

--- a/models/MOM6/model_mod.f90
+++ b/models/MOM6/model_mod.f90
@@ -31,7 +31,8 @@ use netcdf_utilities_mod, only : nc_add_global_attribute, nc_synchronize_file, &
                                  nc_begin_define_mode, nc_end_define_mode, &
                                  nc_open_file_readonly, nc_close_file, &
                                  nc_get_variable, nc_get_variable_size, &
-                                 NF90_MAX_NAME, nc_get_attribute_from_variable
+                                 NF90_MAX_NAME, nc_get_attribute_from_variable, &
+                                 nc_variable_exists
 
 use        quad_utils_mod,  only : quad_interp_handle, init_quad_interp, &
                                    set_quad_coords, quad_lon_lat_locate, &
@@ -1057,6 +1058,8 @@ sensible_temp = t
 end function sensible_temp
 
 !--------------------------------------------------------------------
+! restart files use Time
+! history files use time
 function read_model_time(filename)
 
 character(len=*), intent(in) :: filename
@@ -1064,22 +1067,29 @@ type(time_type) :: read_model_time
 
 integer :: ncid
 character(len=*), parameter :: routine = 'read_model_time'
-real(r8) :: days
-type(time_type) :: mom6_time
-integer :: dart_base_date_in_days, dart_days
+real(r8) :: days, seconds
+integer :: dart_base_date_in_days, dart_days, dart_seconds
 
 dart_base_date_in_days = 584388 ! 1601 1 1 0 0
 ncid = nc_open_file_readonly(filename, routine)
 
-call nc_get_variable(ncid, 'Time', days, routine)
+if (nc_variable_exists(ncid, 'Time')) then
+   call nc_get_variable(ncid, 'Time', days, routine)
+else
+   call nc_get_variable(ncid, 'time', days, routine)
+endif
 
 call nc_close_file(ncid, routine)
 
-! MOM6 counts days from year 1
-! DART counts days from 1601 
-dart_days = int(days) - dart_base_date_in_days
+! MOM6 counts days from year 1 as a real number
+! DART counts days from 1601 as integer days integer seconds
+dart_days = floor(days)
+seconds = (days - real(dart_days, r8)) * 86400.0_r8
 
-read_model_time = set_time(0,dart_days)
+dart_days = dart_days - dart_base_date_in_days
+dart_seconds = int(seconds)
+
+read_model_time = set_time(dart_seconds,dart_days)
 
 end function read_model_time
 

--- a/models/MOM6/readme.rst
+++ b/models/MOM6/readme.rst
@@ -84,6 +84,12 @@ The namelist options for DART-MOM6 are as follows:
        assimilation_period_seconds  = 0
        use_pseudo_depth = .false. ! use pseudo depth instead of sum(layer thickness) for vertical location
        layer_name = 'Layer' ! name of the layer variable in the restart file
+       reference_year   = 1 ! reference year
+       reference_month  = 1 ! reference month
+       reference_day    = 1 ! reference day
+       reference_hour   = 0 ! reference hour
+       reference_minute = 0 ! reference minute
+       reference_second = 0 ! reference second
        /
 
 * ``template_file`` is a MOM6 restart file. The size and shape of the state variables will be read from this netCDF file.
@@ -111,6 +117,17 @@ The namelist options for DART-MOM6 are as follows:
     - **Clamping lower bound**: Minimum allowed value for the variable when writing out restarts (use 'NA' for no bound).
     - **Clamping upper bound**: Maximum allowed value for the variable when writing out restarts (use 'NA' for no bound).
     - **UPDATE or NO_COPY_BACK**: Use 'UPDATE' to allow DART to update this variable during assimilation, or 'NO_COPY_BACK' to prevent updates (variable will be read but not written back).
+
+* ``reference_year``, ``reference_month``, ``reference_day``, ``reference_hour``, ``reference_minute``, ``reference_second``
+  give the reference date used to interpret the restart file's ``Time`` (or history file's ``time``) variable, which is "days
+  since that reference date". The default is to use the MOM6's own reference date of 0001-01-01. However, if you require a
+  different reference date, you can set these values accordingly and read_model_time will read 'days' from the restart
+  file as 'days since reference date'.
+  
+  .. note:: 
+  
+      If ``reference_year`` is set to a value other than 1, it must be >= 1601, because DART's internal Gregorian calendar
+      uses 1601-01-01 as its reference date.
 
 
 Vertical Coordinate


### PR DESCRIPTION
## Description:
<!--- Describe your changes -->

MOM6 read_model_time

* Allow fractions of days in the time, (variable in the file is real not int)
* Allow time dimension to be called 'Time' or 'time' (restart vs history)
* Allow user to set a reference date different to 0001-01-01:00:00:00

Note the reference data has to be after darts own reference date.
This is for ease of setting the date really.

### Fixes issue
<!--- link to github issue(s) -->
fixes https://github.com/NCAR/DART/issues/959
fixes https://github.com/CROCODILE-CESM/dartobsgen/issues/6

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.

### Tests
Please describe any tests you ran to verify your changes.
Read model time from netcdf files

## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [ ] No dataset needed
