### PR TITLE
Localization test perturbations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -255,6 +255,7 @@ sys_sim5
 sys_sim501
 sys_sim502
 test_sampling_err_table
+test_perturb
 
 # Directories to NOT IGNORE ... same as executable names
 # as far as I know, these must be listed after the executables

--- a/assimilation_code/modules/assimilation/filter_mod.f90
+++ b/assimilation_code/modules/assimilation/filter_mod.f90
@@ -64,7 +64,7 @@ use adaptive_inflate_mod,  only : do_ss_inflate, mean_from_restart, sd_from_rest
 use mpi_utilities_mod,     only : my_task_id, task_sync, broadcast_send, broadcast_recv,      &
                                   task_count
 
-use perturb_mod,           only : perturb_ensemble, PERT_MODEL_MOD, PERT_UNIFORM
+use perturb_mod,           only : perturb_ensemble
 
 use state_vector_io_mod,   only : state_vector_io_init, read_state, write_state, &
                                   set_stage_to_write, get_stage_to_write
@@ -205,9 +205,12 @@ character(len=256) :: output_state_file_list(MAX_NUM_DOMS) = ''
 ! Read in a single file and perturb this to create an ensemble
 logical  :: perturb_from_single_instance = .false.
 real(r8) :: perturbation_amplitude       = 0.2_r8
-! Perturb all variables uniformly for clean test of observation localization
-! Must have perturb_from_single_instance true also to do this
-logical  :: perturb_for_localization_test = .false.
+! How to perturb: 
+!    'model' lets the model_mod do it, falling back to a
+! perturbation that is bitwise across any number of tasks.
+!    'uniform' perturbs every state variable identically, used when testing
+! observation localization.  
+character(len=32) :: perturbation_method = 'model' !  Ignored unless perturb_from_single_instance.
 
 ! File options.  Single vs. Multiple.  really 'unified' or 'combination' vs 'individual'
 logical  :: single_file_in  = .false. ! all copies read  from 1 file
@@ -300,7 +303,7 @@ namelist /filter_nml/ async,     &
    single_file_out,              &
    perturb_from_single_instance, &
    perturbation_amplitude,       &
-   perturb_for_localization_test,&
+   perturbation_method,          &
    compute_posterior,            &
    stages_to_write,              &
    input_state_files,            &
@@ -346,7 +349,6 @@ integer                 :: OBS_VAR_START, OBS_VAR_END, TOTAL_OBS_COPIES
 integer                 :: input_qc_index, DART_qc_index
 integer                 :: num_state_ens_copies
 logical                 :: read_time_from_file
-integer                 :: pert_method ! how to perturb a single instance
 
 integer :: num_extras ! the extra ensemble copies
 
@@ -386,19 +388,6 @@ call timestamp_message('Filter start')
 if(ens_size < 2) then
    write(msgstring, *) 'ens_size in namelist is ', ens_size, ': Must be > 1'
    call error_handler(E_ERR,'filter_main', msgstring, source)
-endif
-
-! perturb_for_localization_test can only be true if perturb_from_single_instance is true
-if(perturb_for_localization_test .and. .not. perturb_from_single_instance) then
-   write(msgstring, *) 'perturb_for_localization_test cannot be true unless  &
-      perturb_from_single_instance is also true in filter_nml'
-   call error_handler(E_ERR,'filter_main', msgstring, source)
-endif
-
-if(perturb_for_localization_test) then
-   pert_method = PERT_UNIFORM
-else
-   pert_method = PERT_MODEL_MOD
 endif
 
 ! informational message to log
@@ -601,7 +590,7 @@ if (perturb_from_single_instance) then
 
    ! Only zero has the time, so broadcast the time to all other copy owners
    call broadcast_time_across_copy_owners(state_ens_handle, time1)
-   call perturb_ensemble(state_ens_handle, ens_size, perturbation_amplitude, pert_method)
+   call perturb_ensemble(state_ens_handle, ens_size, perturbation_amplitude, perturbation_method)
 else
    call error_handler(E_MSG,'filter_main:', &
       'Reading in initial condition/restart data for all ensemble members from file(s)')

--- a/assimilation_code/modules/assimilation/filter_mod.f90
+++ b/assimilation_code/modules/assimilation/filter_mod.f90
@@ -205,6 +205,9 @@ character(len=256) :: output_state_file_list(MAX_NUM_DOMS) = ''
 ! Read in a single file and perturb this to create an ensemble
 logical  :: perturb_from_single_instance = .false.
 real(r8) :: perturbation_amplitude       = 0.2_r8
+! Perturb all variables uniformly for clean test of observation localization
+! Must have perturb_from_single_instance true also to do this
+logical  :: perturb_for_localization_test = .false.
 
 ! File options.  Single vs. Multiple.  really 'unified' or 'combination' vs 'individual'
 logical  :: single_file_in  = .false. ! all copies read  from 1 file
@@ -297,6 +300,7 @@ namelist /filter_nml/ async,     &
    single_file_out,              &
    perturb_from_single_instance, &
    perturbation_amplitude,       &
+   perturb_for_localization_test,&
    compute_posterior,            &
    stages_to_write,              &
    input_state_files,            &
@@ -391,6 +395,13 @@ call set_missing_ok_status(allow_missing_clm)
 allow_missing = get_missing_ok_status()
 
 call trace_message('Before initializing inflation')
+
+! perturb_for_localization_test can only be true if perturb_from_single_instance is true
+if(perturb_for_localization_test .and. .not. perturb_from_single_instance) then
+   write(msgstring, *) 'perturb_for_localization_test cannot be true unless  &
+      perturb_from_single_instance is also true in filter_nml'
+   call error_handler(E_ERR,'filter_main', msgstring, source)
+endif  
 
 call validate_inflate_options(inf_flavor, inf_damping, inf_initial_from_restart, &
    inf_sd_initial_from_restart, inf_deterministic, inf_sd_max_change,            &
@@ -2117,9 +2128,15 @@ if (get_missing_ok_status()) then
    where(ens_handle%copies(1, :) == missing_r8) miss_me = .true.
 endif
 
-call pert_model_copies(ens_handle, ens_size, perturbation_amplitude, interf_provided)
-if (.not. interf_provided) then
-   call perturb_copies_task_bitwise(ens_handle)
+! Uniform perturbation used for localization verification tests
+if(perturb_for_localization_test) then
+   call perturb_copies_uniform(ens_handle)
+else
+   ! Let model do perturbations if it is prepared to do so
+   call pert_model_copies(ens_handle, ens_size, perturbation_amplitude, interf_provided)
+   if (.not. interf_provided) then
+      call perturb_copies_task_bitwise(ens_handle)
+   endif
 endif
 
 ! Restore the missing_r8
@@ -2171,6 +2188,27 @@ do i = 1, ens_handle%num_vars
 enddo
 
 end subroutine perturb_copies_task_bitwise
+
+!------------------------------------------------------------------
+! Perturb the copies array uniformly for localization tests
+! The covariance between an observation and any state variable should be
+! the same.
+
+subroutine perturb_copies_uniform(ens_handle)
+
+type(ensemble_type), intent(inout) :: ens_handle
+
+integer               :: i, j ! loop variables
+   
+! Perturbation magnitude is the constant perturbation_amplitude from namelist
+do i = 1, ens_handle%my_num_vars
+   do j = 2, ens_size
+      ens_handle%copies(j, i) = ens_handle%copies(1, i) + &
+         (j - 1.0_r8) * perturbation_amplitude
+   end do
+end do
+
+end subroutine perturb_copies_uniform
 
 !------------------------------------------------------------------
 !> Set the time on any extra copies that a pe owns

--- a/assimilation_code/modules/assimilation/filter_mod.f90
+++ b/assimilation_code/modules/assimilation/filter_mod.f90
@@ -35,7 +35,7 @@ use utilities_mod,         only : error_handler, E_ERR, E_MSG, E_DBG,           
                                   set_multiple_filename_lists, find_textfile_dims
 
 use assim_model_mod,       only : static_init_assim_model, get_model_size,                    &
-                                  end_assim_model,  pert_model_copies, get_state_meta_data
+                                  end_assim_model,  get_state_meta_data
 
 use assim_tools_mod,       only : filter_assim, set_assim_tools_trace, test_state_copies
 use obs_model_mod,         only : move_ahead, advance_state, set_obs_model_trace
@@ -64,7 +64,7 @@ use adaptive_inflate_mod,  only : do_ss_inflate, mean_from_restart, sd_from_rest
 use mpi_utilities_mod,     only : my_task_id, task_sync, broadcast_send, broadcast_recv,      &
                                   task_count
 
-use random_seq_mod,        only : random_seq_type, init_random_seq, random_gaussian
+use perturb_mod,           only : perturb_ensemble, PERT_MODEL_MOD, PERT_UNIFORM
 
 use state_vector_io_mod,   only : state_vector_io_init, read_state, write_state, &
                                   set_stage_to_write, get_stage_to_write
@@ -346,6 +346,7 @@ integer                 :: OBS_VAR_START, OBS_VAR_END, TOTAL_OBS_COPIES
 integer                 :: input_qc_index, DART_qc_index
 integer                 :: num_state_ens_copies
 logical                 :: read_time_from_file
+integer                 :: pert_method ! how to perturb a single instance
 
 integer :: num_extras ! the extra ensemble copies
 
@@ -387,6 +388,19 @@ if(ens_size < 2) then
    call error_handler(E_ERR,'filter_main', msgstring, source)
 endif
 
+! perturb_for_localization_test can only be true if perturb_from_single_instance is true
+if(perturb_for_localization_test .and. .not. perturb_from_single_instance) then
+   write(msgstring, *) 'perturb_for_localization_test cannot be true unless  &
+      perturb_from_single_instance is also true in filter_nml'
+   call error_handler(E_ERR,'filter_main', msgstring, source)
+endif
+
+if(perturb_for_localization_test) then
+   pert_method = PERT_UNIFORM
+else
+   pert_method = PERT_MODEL_MOD
+endif
+
 ! informational message to log
 write(msgstring, '(A,I5)') 'running with an ensemble size of ', ens_size
 call error_handler(E_MSG,'filter_main:', msgstring, source)
@@ -395,13 +409,6 @@ call set_missing_ok_status(allow_missing_clm)
 allow_missing = get_missing_ok_status()
 
 call trace_message('Before initializing inflation')
-
-! perturb_for_localization_test can only be true if perturb_from_single_instance is true
-if(perturb_for_localization_test .and. .not. perturb_from_single_instance) then
-   write(msgstring, *) 'perturb_for_localization_test cannot be true unless  &
-      perturb_from_single_instance is also true in filter_nml'
-   call error_handler(E_ERR,'filter_main', msgstring, source)
-endif  
 
 call validate_inflate_options(inf_flavor, inf_damping, inf_initial_from_restart, &
    inf_sd_initial_from_restart, inf_deterministic, inf_sd_max_change,            &
@@ -594,7 +601,7 @@ if (perturb_from_single_instance) then
 
    ! Only zero has the time, so broadcast the time to all other copy owners
    call broadcast_time_across_copy_owners(state_ens_handle, time1)
-   call create_ensemble_from_single_file(state_ens_handle)
+   call perturb_ensemble(state_ens_handle, ens_size, perturbation_amplitude, pert_method)
 else
    call error_handler(E_MSG,'filter_main:', &
       'Reading in initial condition/restart data for all ensemble members from file(s)')
@@ -2088,127 +2095,6 @@ end do
 call close_file(forward_unit)
 
 end subroutine verbose_forward_op_output
-
-!------------------------------------------------------------------
-!> Produces an ensemble by copying my_vars of the 1st ensemble member
-!> and then perturbing the copies array.
-!> Mimicks the behaviour of pert_model_state:
-!> pert_model_copies is called:
-!>   if no model perturb is provided, perturb_copies_task_bitwise is called.
-!> Note: Not enforcing a model_mod to produce a
-!> pert_model_copies that is bitwise across any number of
-!> tasks, although there is enough information in the
-!> ens_handle to do this.
-!>
-!> Some models allow missing_r8 in the state vector.  If missing_r8 is
-!> allowed the locations of missing_r8s are stored before the perturb,
-!> then the missing_r8s are put back in after the perturb.
-
-subroutine create_ensemble_from_single_file(ens_handle)
-
-type(ensemble_type), intent(inout) :: ens_handle
-
-integer               :: i
-logical               :: interf_provided ! model does the perturbing
-logical, allocatable  :: miss_me(:)
-integer               :: partial_state_on_my_task ! the number of elements ON THIS TASK
-
-! Copy from ensemble member 1 to the other copies
-do i = 1, ens_handle%my_num_vars
-   ens_handle%copies(2:ens_size, i) = ens_handle%copies(1, i)  ! How slow is this?
-enddo
-
-! If the state allows missing values, we have to record their locations
-! and restore them in all the new perturbed copies.
-
-if (get_missing_ok_status()) then
-   partial_state_on_my_task = size(ens_handle%copies,2)
-   allocate(miss_me(partial_state_on_my_task))
-   miss_me = .false.
-   where(ens_handle%copies(1, :) == missing_r8) miss_me = .true.
-endif
-
-! Uniform perturbation used for localization verification tests
-if(perturb_for_localization_test) then
-   call perturb_copies_uniform(ens_handle)
-else
-   ! Let model do perturbations if it is prepared to do so
-   call pert_model_copies(ens_handle, ens_size, perturbation_amplitude, interf_provided)
-   if (.not. interf_provided) then
-      call perturb_copies_task_bitwise(ens_handle)
-   endif
-endif
-
-! Restore the missing_r8
-if (get_missing_ok_status()) then
-   do i = 1, ens_size
-      where(miss_me) ens_handle%copies(i, :) = missing_r8
-   enddo
-   deallocate(miss_me)
-endif
-
-end subroutine create_ensemble_from_single_file
-
-
-!------------------------------------------------------------------
-! Perturb the copies array in a way that is bitwise reproducible
-! no matter how many task you run on.
-
-subroutine perturb_copies_task_bitwise(ens_handle)
-
-type(ensemble_type), intent(inout) :: ens_handle
-
-integer               :: i, j ! loop variables
-type(random_seq_type) :: r(ens_size)
-real(r8)              :: random_array(ens_size) ! array of random numbers
-integer               :: local_index
-
-! Need ens_size random number sequences.
-do i = 1, ens_size
-   call init_random_seq(r(i), i)
-enddo
-
-local_index = 1 ! same across the ensemble
-
-! Only one task is going to update per i.  This will not scale at all.
-do i = 1, ens_handle%num_vars
-
-   do j = 1, ens_size
-     ! Can use %copies here because the random number
-     ! is only relevant to the task than owns element i.
-     random_array(j)  =  random_gaussian(r(j), ens_handle%copies(j, local_index), perturbation_amplitude)
-   enddo
-
-   if (ens_handle%my_vars(local_index) == i) then
-      ens_handle%copies(1:ens_size, local_index) = random_array(:)
-      local_index = local_index + 1 ! task is ready for the next random number
-      local_index = min(local_index, ens_handle%my_num_vars)
-   endif
-
-enddo
-
-end subroutine perturb_copies_task_bitwise
-
-!------------------------------------------------------------------
-! Perturb the copies array uniformly for localization tests
-! The covariance between an observation and any state variable should be
-! the same.
-
-subroutine perturb_copies_uniform(ens_handle)
-
-type(ensemble_type), intent(inout) :: ens_handle
-
-integer               :: i, j ! loop variables
-   
-! Perturbation magnitude is the constant perturbation_amplitude from namelist
-do i = 1, ens_handle%my_num_vars
-   do j = 2, ens_size
-      ens_handle%copies(j, i) = ens_handle%copies(1, i) + &
-         (j - 1.0_r8) * perturbation_amplitude
-   end do
-end do
-
-end subroutine perturb_copies_uniform
 
 !------------------------------------------------------------------
 !> Set the time on any extra copies that a pe owns

--- a/assimilation_code/modules/assimilation/filter_mod.f90
+++ b/assimilation_code/modules/assimilation/filter_mod.f90
@@ -586,7 +586,8 @@ call log_inflation_info(post_inflate, state_ens_handle%my_pe, 'Posterior', singl
 
 if (perturb_from_single_instance) then
    call error_handler(E_MSG,'filter_main:', &
-      'Reading in a single member and perturbing data for the other ensemble members')
+      'Reading in a single member and perturbing data for the other ensemble members', &
+      text2='perturbation_method = '//trim(perturbation_method))
 
    ! Only zero has the time, so broadcast the time to all other copy owners
    call broadcast_time_across_copy_owners(state_ens_handle, time1)

--- a/assimilation_code/modules/assimilation/filter_mod.nml
+++ b/assimilation_code/modules/assimilation/filter_mod.nml
@@ -6,7 +6,7 @@
    init_time_seconds            = 0,
    perturb_from_single_instance = .false.,
    perturbation_amplitude       = 0.2,
-   perturbation_locatlization_test = .false.,
+   perturb_for_localization_test = .false.,
 
    stages_to_write              = 'output'
 

--- a/assimilation_code/modules/assimilation/filter_mod.nml
+++ b/assimilation_code/modules/assimilation/filter_mod.nml
@@ -6,7 +6,7 @@
    init_time_seconds            = 0,
    perturb_from_single_instance = .false.,
    perturbation_amplitude       = 0.2,
-   perturb_for_localization_test = .false.,
+   perturbation_method          = 'model',
 
    stages_to_write              = 'output'
 

--- a/assimilation_code/modules/assimilation/filter_mod.nml
+++ b/assimilation_code/modules/assimilation/filter_mod.nml
@@ -6,6 +6,7 @@
    init_time_seconds            = 0,
    perturb_from_single_instance = .false.,
    perturbation_amplitude       = 0.2,
+   perturbation_locatlization_test = .false.,
 
    stages_to_write              = 'output'
 

--- a/assimilation_code/modules/assimilation/filter_mod.rst
+++ b/assimilation_code/modules/assimilation/filter_mod.rst
@@ -33,7 +33,7 @@ namelist.
       init_time_seconds            = 0,
       perturb_from_single_instance = .false.,
       perturbation_amplitude       = 0.2,
-      perturbation_localization_test = .false.,
+      perturb_for_localization_test = .false.,
 
       stages_to_write              = 'output'
 
@@ -146,9 +146,9 @@ prior inflation and the second controls the posterior inflation.
 |                              |                     | ``pert_model_copies``. For more,          |
 |                              |                     | see pert_model_copies_  below.            |
 |                              |                     | Ignored if                                |
-|                              |                     | ``perturb_from_single_instance= .false.`` | 
+|                              |                     | ``perturb_from_single_instance = .false.``|
 +------------------------------+---------------------+-------------------------------------------+
-| perturbation_amplitude       | logical             | Can only be true if                       |
+| perturb_for_localization_test| logical             | Can only be true if                       |
 |                              |                     | ``perturb_from_single_instance = .true.`` |
 |                              |                     | If both are true, ensemble perturbations  |
 |                              |                     | are the same for every state variable.    |

--- a/assimilation_code/modules/assimilation/filter_mod.rst
+++ b/assimilation_code/modules/assimilation/filter_mod.rst
@@ -155,9 +155,9 @@ prior inflation and the second controls the posterior inflation.
 |                              |                     | ``pert_model_copies``, falling back to a  |
 |                              |                     | perturbation that is bitwise across any   |
 |                              |                     | number of tasks if the model does not     |
-|                              |                     | provide that interface. 'uniform' gives   |
-|                              |                     | every state variable the same set of      |
-|                              |                     | member perturbations, so the covariance   |
+|                              |                     | provide that interface. 'uniform' sets    |
+|                              |                     | ensemble perturbations the same for every |
+|                              |                     | state variable, so the covariance         |
 |                              |                     | of an observation with any state variable |
 |                              |                     | is identical. This leaves the             |
 |                              |                     | localization as the only thing causing    |
@@ -170,7 +170,7 @@ prior inflation and the second controls the posterior inflation.
 |                              |                     | x, x_i is the value of the ith perturbed  |
 |                              |                     | member and pa is                          |
 |                              |                     | ``perturbation_amplitude``. Ignored if    |
-|                              |                     | perturb_from_single_instance = .false.    |
+|                              |                     | ``perturb_from_single_instance = .false.``|
 +------------------------------+---------------------+-------------------------------------------+
 | stages_to_write              | character(len=10),  | Controls diagnostic and restart output.   |
 |                              | dimension(6)        | Valid values are: 'input', 'forecast',    |

--- a/assimilation_code/modules/assimilation/filter_mod.rst
+++ b/assimilation_code/modules/assimilation/filter_mod.rst
@@ -33,7 +33,7 @@ namelist.
       init_time_seconds            = 0,
       perturb_from_single_instance = .false.,
       perturbation_amplitude       = 0.2,
-      perturb_for_localization_test = .false.,
+      perturbation_method          = 'model',
 
       stages_to_write              = 'output'
 
@@ -148,22 +148,29 @@ prior inflation and the second controls the posterior inflation.
 |                              |                     | Ignored if                                |
 |                              |                     | ``perturb_from_single_instance = .false.``|
 +------------------------------+---------------------+-------------------------------------------+
-| perturb_for_localization_test| logical             | Can only be true if                       |
-|                              |                     | ``perturb_from_single_instance = .true.`` |
-|                              |                     | If both are true, ensemble perturbations  |
-|                              |                     | are the same for every state variable.    |
-|                              |                     | This means that the covariance of an      |
-|                              |                     | observation with any state variable is    |
-|                              |                     | identical. This leaves the localization   |
-|                              |                     | as the only thing causing variability in  |
-|                              |                     | increments making it easy to display      |
-|                              |                     | the details of the localization. The      |
-|                              |                     | perturbed state variable values are       |
-|                              |                     | x_i = x_1 + (i-1) * pa where x_1 is the   |
-|                              |                     | value of the single member being          |
-|                              |                     | perturbed for state variable x, x_i is    |
-|                              |                     | the value of the ith perturbed member     |
-|                              |                     | and pa is ``perturbation_amplitude``.     |
+| perturbation_method          | character(len=32)   | How to perturb when                       |
+|                              |                     | perturb_from_single_instance = .true.     |
+|                              |                     | Case insensitive. 'model' lets the        |
+|                              |                     | model_mod perturb via                     |
+|                              |                     | ``pert_model_copies``, falling back to a  |
+|                              |                     | perturbation that is bitwise across any   |
+|                              |                     | number of tasks if the model does not     |
+|                              |                     | provide that interface. 'uniform' gives   |
+|                              |                     | every state variable the same set of      |
+|                              |                     | member perturbations, so the covariance   |
+|                              |                     | of an observation with any state variable |
+|                              |                     | is identical. This leaves the             |
+|                              |                     | localization as the only thing causing    |
+|                              |                     | variability in increments, making it easy |
+|                              |                     | to display the details of the             |
+|                              |                     | localization. The perturbed state         |
+|                              |                     | variable values are x_i=x_1+(i-1)*pa      |
+|                              |                     | where x_1 is the value of the single      |
+|                              |                     | member being perturbed for state variable |
+|                              |                     | x, x_i is the value of the ith perturbed  |
+|                              |                     | member and pa is                          |
+|                              |                     | ``perturbation_amplitude``. Ignored if    |
+|                              |                     | perturb_from_single_instance = .false.    |
 +------------------------------+---------------------+-------------------------------------------+
 | stages_to_write              | character(len=10),  | Controls diagnostic and restart output.   |
 |                              | dimension(6)        | Valid values are: 'input', 'forecast',    |

--- a/assimilation_code/modules/assimilation/filter_mod.rst
+++ b/assimilation_code/modules/assimilation/filter_mod.rst
@@ -33,6 +33,7 @@ namelist.
       init_time_seconds            = 0,
       perturb_from_single_instance = .false.,
       perturbation_amplitude       = 0.2,
+      perturbation_localization_test = .false.,
 
       stages_to_write              = 'output'
 
@@ -145,7 +146,24 @@ prior inflation and the second controls the posterior inflation.
 |                              |                     | ``pert_model_copies``. For more,          |
 |                              |                     | see pert_model_copies_  below.            |
 |                              |                     | Ignored if                                |
-|                              |                     | ``perturb_from_single_instance = .false.``| 
+|                              |                     | ``perturb_from_single_instance= .false.`` | 
++------------------------------+---------------------+-------------------------------------------+
+| perturbation_amplitude       | logical             | Can only be true if                       |
+|                              |                     | ``perturb_from_single_instance = .true.`` |
+|                              |                     | If both are true, ensemble perturbations  |
+|                              |                     | are the same for every state variable.    |
+|                              |                     | This means that the covariance of an      |
+|                              |                     | observation with any state variable is    |
+|                              |                     | identical. This leaves the localization   |
+|                              |                     | as the only thing causing variability in  |
+|                              |                     | increments making it easy to display      |
+|                              |                     | the details of the localization. The      |
+|                              |                     | perturbed state variable values are       |
+|                              |                     | x_i = x_1 + (i-1) * pa where x_1 is the   |
+|                              |                     | value of the single member being          |
+|                              |                     | perturbed for state variable x, x_i is    |
+|                              |                     | the value of the ith perturbed member     |
+|                              |                     | and pa is ``perturbation_amplitude``.     |
 +------------------------------+---------------------+-------------------------------------------+
 | stages_to_write              | character(len=10),  | Controls diagnostic and restart output.   |
 |                              | dimension(6)        | Valid values are: 'input', 'forecast',    |

--- a/assimilation_code/modules/assimilation/perturb_mod.f90
+++ b/assimilation_code/modules/assimilation/perturb_mod.f90
@@ -40,7 +40,7 @@ implicit none
 private
 
 public :: perturb_ensemble, &
-          perturb_uniform,  &
+          perturb_uniform, &
           perturb_bitwise
 
 character(len=*), parameter :: source = 'perturb_mod.f90'
@@ -104,6 +104,7 @@ select case (trim(uc_method))
    case ('MODEL')
       ! Let model do perturbations if it is prepared to do so
       call pert_model_copies(ens_handle, ens_size, amplitude, interf_provided)
+      ! Otherwise perturb with Gaussian random draws here
       if (.not. interf_provided) then
          call perturb_bitwise(ens_handle%copies, ens_size, ens_handle%my_vars, &
                               ens_handle%num_vars, amplitude)
@@ -182,7 +183,7 @@ integer               :: my_num_vars
 
 my_num_vars = size(copies, 2)
 
-! If a task owns no part of the state, so it has nothing to write.  Return
+! If a task owns no part of the state, it has nothing to write.  Return
 ! before local_index is used to index copies, which would be out of bounds.
 ! I think DART currently does not allow num_procs > num_vars, but this is
 ! not an expensive safety check for perturbs (called once).
@@ -200,7 +201,7 @@ do i = 1, num_vars
 
    do j = 1, ens_size
      ! Can use copies here because the random number
-     ! is only relevant to the task than owns element i.
+     ! is only relevant to the task that owns element i.
      random_array(j)  =  random_gaussian(r(j), copies(j, local_index), amplitude)
    enddo
 

--- a/assimilation_code/modules/assimilation/perturb_mod.f90
+++ b/assimilation_code/modules/assimilation/perturb_mod.f90
@@ -26,7 +26,7 @@ module perturb_mod
 
 use types_mod,            only : r8, i8, missing_r8
 
-use utilities_mod,        only : error_handler, E_ERR
+use utilities_mod,        only : error_handler, E_ERR, to_upper
 
 use options_mod,          only : get_missing_ok_status
 
@@ -41,30 +41,25 @@ private
 
 public :: perturb_ensemble, &
           perturb_uniform,  &
-          perturb_bitwise,  &
-          PERT_MODEL_MOD,   &
-          PERT_UNIFORM
+          perturb_bitwise
 
 character(len=*), parameter :: source = 'perturb_mod.f90'
-
-! Perturbation methods
-integer, parameter :: PERT_MODEL_MOD = 1 ! model_mod does it, bitwise fallback
-integer, parameter :: PERT_UNIFORM   = 2 ! uniform ladder, for localization tests
 
 contains
 
 !------------------------------------------------------------------
 !> Create an ensemble from the single instance held in copy 1.
 !>
-!> Copy 1 is copied to the other members and then perturbed.  For
-!> PERT_MODEL_MOD the model_mod is given the chance to do the perturbing
-!> via pert_model_copies; if it does not provide that interface,
-!> perturb_bitwise is used instead.
-!>   if no model perturb is provided, perturb_copies_task_bitwise is called.
-!> Note: Not enforcing a model_mod to produce a
-!> pert_model_copies that is bitwise across any number of
-!> tasks, although there is enough information in the
-!> ens_handle to do this.
+!> Copy 1 is copied to the other members and then perturbed.  method selects
+!> how, and is matched case insensitively:
+!>
+!>   'model'   - the model_mod is given the chance to perturb via
+!>               pert_model_copies.  If it does not provide that interface,
+!>               perturb_bitwise is used instead.  Note: not enforcing a
+!>               model_mod to produce a pert_model_copies that is bitwise
+!>               across any number of tasks, although there is enough
+!>               information in the ens_handle to do this.
+!>   'uniform' - perturb_uniform, for localization tests.
 !>
 !> Some models allow missing_r8 in the state vector.  If missing_r8 is
 !> allowed the locations of missing_r8s are stored before the perturb,
@@ -75,12 +70,13 @@ subroutine perturb_ensemble(ens_handle, ens_size, amplitude, method)
 type(ensemble_type), intent(inout) :: ens_handle
 integer,             intent(in)    :: ens_size
 real(r8),            intent(in)    :: amplitude
-integer,             intent(in)    :: method
+character(len=*),    intent(in)    :: method
 
-integer               :: i
-logical               :: interf_provided ! model does the perturbing
-logical, allocatable  :: miss_me(:)
-integer               :: partial_state_on_my_task ! the number of elements ON THIS TASK
+integer                     :: i
+logical                     :: interf_provided ! model does the perturbing
+logical, allocatable        :: miss_me(:)
+integer                     :: partial_state_on_my_task ! the number of elements ON THIS TASK
+character(len=len(method))  :: uc_method ! method, upper case for comparison
 
 ! Copy from ensemble member 1 to the other copies
 do i = 1, ens_handle%my_num_vars
@@ -97,12 +93,15 @@ if (get_missing_ok_status()) then
    where(ens_handle%copies(1, :) == missing_r8) miss_me = .true.
 endif
 
-select case (method)
+uc_method = adjustl(method)
+call to_upper(uc_method)
 
-   case (PERT_UNIFORM)
+select case (trim(uc_method))
+
+   case ('UNIFORM')
       call perturb_uniform(ens_handle%copies, ens_size, amplitude)
 
-   case (PERT_MODEL_MOD)
+   case ('MODEL')
       ! Let model do perturbations if it is prepared to do so
       call pert_model_copies(ens_handle, ens_size, amplitude, interf_provided)
       if (.not. interf_provided) then
@@ -112,7 +111,8 @@ select case (method)
 
    case default
       call error_handler(E_ERR,'perturb_ensemble', &
-         'unknown perturbation method', source)
+         'unknown perturbation_method "'//trim(adjustl(method))// &
+         '", must be "model" or "uniform"', source)
 
 end select
 

--- a/assimilation_code/modules/assimilation/perturb_mod.f90
+++ b/assimilation_code/modules/assimilation/perturb_mod.f90
@@ -1,0 +1,219 @@
+! DART software - Copyright UCAR. This open source software is provided
+! by UCAR, "as is", without charge, subject to all terms of use at
+! http://www.image.ucar.edu/DAReS/DART/DART_download
+!
+! Create an ensemble by perturbing a single state instance.
+!
+! This module has two layers:
+!
+!   perturb_ensemble  - the handle level entry point.  It owns the policy:
+!                       copying member 1 to the other members, saving and
+!                       restoring missing_r8, choosing the perturbation
+!                       method and falling back when the model provides no
+!                       pert_model_copies.  Callers pass their own namelist
+!                       values in as arguments; this module reads no namelist
+!                       of its own because its callers read different ones.
+!
+!   perturb_uniform,  - the array level routines.  These take the copies array
+!   perturb_bitwise     and the ensemble distribution as plain data so they
+!                       can be tested without an ensemble handle.
+!
+! Note that ens_size is always an explicit argument.  It is NOT size(copies,1),
+! because filter carries extra copies (mean, sd, inflation) beyond the ensemble
+! members.
+
+module perturb_mod
+
+use types_mod,            only : r8, i8, missing_r8
+
+use utilities_mod,        only : error_handler, E_ERR
+
+use options_mod,          only : get_missing_ok_status
+
+use assim_model_mod,      only : pert_model_copies
+
+use ensemble_manager_mod, only : ensemble_type
+
+use random_seq_mod,       only : random_seq_type, init_random_seq, random_gaussian
+
+implicit none
+private
+
+public :: perturb_ensemble, &
+          perturb_uniform,  &
+          perturb_bitwise,  &
+          PERT_MODEL_MOD,   &
+          PERT_UNIFORM
+
+character(len=*), parameter :: source = 'perturb_mod.f90'
+
+! Perturbation methods
+integer, parameter :: PERT_MODEL_MOD = 1 ! model_mod does it, bitwise fallback
+integer, parameter :: PERT_UNIFORM   = 2 ! uniform ladder, for localization tests
+
+contains
+
+!------------------------------------------------------------------
+!> Create an ensemble from the single instance held in copy 1.
+!>
+!> Copy 1 is copied to the other members and then perturbed.  For
+!> PERT_MODEL_MOD the model_mod is given the chance to do the perturbing
+!> via pert_model_copies; if it does not provide that interface,
+!> perturb_bitwise is used instead.
+!>   if no model perturb is provided, perturb_copies_task_bitwise is called.
+!> Note: Not enforcing a model_mod to produce a
+!> pert_model_copies that is bitwise across any number of
+!> tasks, although there is enough information in the
+!> ens_handle to do this.
+!>
+!> Some models allow missing_r8 in the state vector.  If missing_r8 is
+!> allowed the locations of missing_r8s are stored before the perturb,
+!> then the missing_r8s are put back in after the perturb.
+
+subroutine perturb_ensemble(ens_handle, ens_size, amplitude, method)
+
+type(ensemble_type), intent(inout) :: ens_handle
+integer,             intent(in)    :: ens_size
+real(r8),            intent(in)    :: amplitude
+integer,             intent(in)    :: method
+
+integer               :: i
+logical               :: interf_provided ! model does the perturbing
+logical, allocatable  :: miss_me(:)
+integer               :: partial_state_on_my_task ! the number of elements ON THIS TASK
+
+! Copy from ensemble member 1 to the other copies
+do i = 1, ens_handle%my_num_vars
+   ens_handle%copies(2:ens_size, i) = ens_handle%copies(1, i)  ! How slow is this?
+enddo
+
+! If the state allows missing values, we have to record their locations
+! and restore them in all the new perturbed copies.
+
+if (get_missing_ok_status()) then
+   partial_state_on_my_task = size(ens_handle%copies,2)
+   allocate(miss_me(partial_state_on_my_task))
+   miss_me = .false.
+   where(ens_handle%copies(1, :) == missing_r8) miss_me = .true.
+endif
+
+select case (method)
+
+   case (PERT_UNIFORM)
+      call perturb_uniform(ens_handle%copies, ens_size, amplitude)
+
+   case (PERT_MODEL_MOD)
+      ! Let model do perturbations if it is prepared to do so
+      call pert_model_copies(ens_handle, ens_size, amplitude, interf_provided)
+      if (.not. interf_provided) then
+         call perturb_bitwise(ens_handle%copies, ens_size, ens_handle%my_vars, &
+                              ens_handle%num_vars, amplitude)
+      endif
+
+   case default
+      call error_handler(E_ERR,'perturb_ensemble', &
+         'unknown perturbation method', source)
+
+end select
+
+! Restore the missing_r8
+if (get_missing_ok_status()) then
+   do i = 1, ens_size
+      where(miss_me) ens_handle%copies(i, :) = missing_r8
+   enddo
+   deallocate(miss_me)
+endif
+
+end subroutine perturb_ensemble
+
+!------------------------------------------------------------------
+!> Perturb the copies array uniformly for localization tests.
+!>
+!> Every state variable is given the same set of member offsets, so the
+!> ensemble deviations do not depend on the state index.  Every state
+!> variable then has the same spread, and the covariance between an
+!> observation and any state variable is identical.  That leaves the
+!> localization as the only source of variability in the increments.
+!>
+!> The perturbed values are x_j = x_1 + (j-1)*amplitude, so amplitude is a
+!> spacing rather than a standard deviation.  The resulting spread is
+!> amplitude*sqrt(N(N+1)/12) and grows with the ensemble size.
+
+subroutine perturb_uniform(copies, ens_size, amplitude)
+
+real(r8), intent(inout) :: copies(:,:) ! (num_copies, my_num_vars)
+integer,  intent(in)    :: ens_size
+real(r8), intent(in)    :: amplitude
+
+integer :: i, j ! loop variables
+
+do i = 1, size(copies, 2)
+   do j = 2, ens_size
+      copies(j, i) = copies(1, i) + (j - 1.0_r8) * amplitude
+   end do
+end do
+
+end subroutine perturb_uniform
+
+!------------------------------------------------------------------
+!> Perturb the copies array in a way that is bitwise reproducible
+!> no matter how many tasks you run on.
+!>
+!> Every task walks the whole global state and draws the same random
+!> numbers, but only writes the elements it owns. Bitwise across task
+!> counts, but the cost is proportional to the global state size on 
+!> every task -> so does not scale at all
+!>
+
+subroutine perturb_bitwise(copies, ens_size, my_vars, num_vars, amplitude)
+
+real(r8),    intent(inout) :: copies(:,:) ! (num_copies, my_num_vars)
+integer,     intent(in)    :: ens_size
+integer(i8), intent(in)    :: my_vars(:)  ! global index of each local element
+integer(i8), intent(in)    :: num_vars    ! global number of state elements
+real(r8),    intent(in)    :: amplitude
+
+integer(i8)           :: i ! global state index
+integer               :: j ! loop variable
+type(random_seq_type) :: r(ens_size)
+real(r8)              :: random_array(ens_size) ! array of random numbers
+integer               :: local_index
+integer               :: my_num_vars
+
+my_num_vars = size(copies, 2)
+
+! If a task owns no part of the state, so it has nothing to write.  Return
+! before local_index is used to index copies, which would be out of bounds.
+! I think DART currently does not allow num_procs > num_vars, but this is
+! not an expensive safety check for perturbs (called once).
+if (my_num_vars < 1) return
+
+! Need ens_size random number sequences.
+do j = 1, ens_size
+   call init_random_seq(r(j), j)
+enddo
+
+local_index = 1 ! same across the ensemble
+
+! Only one task is going to update per i.  This will not scale at all.
+do i = 1, num_vars
+
+   do j = 1, ens_size
+     ! Can use copies here because the random number
+     ! is only relevant to the task than owns element i.
+     random_array(j)  =  random_gaussian(r(j), copies(j, local_index), amplitude)
+   enddo
+
+   if (my_vars(local_index) == i) then
+      copies(1:ens_size, local_index) = random_array(:)
+      local_index = local_index + 1 ! task is ready for the next random number
+      local_index = min(local_index, my_num_vars)
+   endif
+
+enddo
+
+end subroutine perturb_bitwise
+
+!------------------------------------------------------------------
+
+end module perturb_mod

--- a/assimilation_code/programs/perturb_single_instance/perturb_single_instance.f90
+++ b/assimilation_code/programs/perturb_single_instance/perturb_single_instance.f90
@@ -4,7 +4,7 @@
 
 
 !> This is a utility program that computes an ensemble of restarts
-!> using the model_mod pert_model_copies
+!> by perturbing a single instance.  
 
 program perturb_single_instance
 
@@ -26,7 +26,7 @@ use  obs_kind_mod,        only : get_num_quantities, get_index_for_quantity, &
 use  sort_mod,            only : index_sort
 
 use assim_model_mod,      only : static_init_assim_model, get_model_size, &
-                                 get_state_meta_data, pert_model_copies
+                                 get_state_meta_data
 
 use state_vector_io_mod,  only : read_state, write_state
 
@@ -43,7 +43,9 @@ use mpi_utilities_mod,    only : initialize_mpi_utilities, task_count, &
                                  send_sum_to
 
 use ensemble_manager_mod, only : ensemble_type, init_ensemble_manager, compute_copy_mean, &
-                                 get_my_num_vars, end_ensemble_manager
+                                 end_ensemble_manager
+
+use perturb_mod,          only : perturb_ensemble, PERT_MODEL_MOD, PERT_UNIFORM
 
 implicit none
 
@@ -58,6 +60,8 @@ character(len=256)    :: output_file_list(MAX_NUM_DOMS) = ''
 character(len=256)    :: output_files(MAX_FILES)        = '' 
 real(r8)              :: perturbation_amplitude         = 0.0
 logical               :: single_restart_file_in         = .false.
+! Perturb all variables uniformly for a clean test of observation localization
+logical               :: perturb_for_localization_test  = .false.
 
 namelist /perturb_single_instance_nml/  &
    ens_size,                &
@@ -65,6 +69,7 @@ namelist /perturb_single_instance_nml/  &
    output_files,            &
    output_file_list,        &
    perturbation_amplitude,  &
+   perturb_for_localization_test, &
    single_restart_file_in
 
 !----------------------------------------------------------------
@@ -75,9 +80,9 @@ character(len=256), allocatable :: file_array_input(:,:)
 character(len=256), allocatable :: file_array_output(:,:)
 character(len=512)              :: msgstring, msgstring1
 character(len=256)              :: my_base, my_desc
-integer                         :: idom, imem, iunit, io, i
+integer                         :: idom, imem, iunit, io
 integer                         :: ndomains
-logical                         :: interf_provided
+integer                         :: pert_method ! how to perturb the single instance
 integer(i8)                     :: model_size
 type(time_type)                 :: member_time
 type(file_info_type)            :: file_info_input, file_info_output
@@ -103,6 +108,12 @@ if (single_restart_file_in) then
    write(msgstring,  *) 'single_restart_file_in is not supported.'
    write(msgstring1, *) 'Please contact DART if you would like to use this capability.'
    call error_handler(E_ERR,msgstring,msgstring1)
+endif
+
+if (perturb_for_localization_test) then
+   pert_method = PERT_UNIFORM
+else
+   pert_method = PERT_MODEL_MOD
 endif
 
 !----------------------------------------------------------------------
@@ -185,16 +196,11 @@ member_time = set_time_missing()
 call read_state(ens_handle, file_info_input, read_time_from_file=.true., model_time=member_time)
 
 !----------------------------------------------------------------------
-! Copy from ensemble member 1 to the other copies
+! Copy member 1 to the other members and perturb them.  If the model
+! provides no pert_model_copies, perturb_ensemble falls back to a
+! perturbation that is bitwise across any number of tasks.
 !----------------------------------------------------------------------
-do i = 1, get_my_num_vars(ens_handle)
-   ens_handle%copies(2:ens_size, i) = ens_handle%copies(1, i)
-enddo
-
-call pert_model_copies(ens_handle, ens_size, perturbation_amplitude, interf_provided)
-if (.not. interf_provided) then
-   call error_handler(E_ERR, 'model_mod::pert_model_copies interface required', source)
-endif 
+call perturb_ensemble(ens_handle, ens_size, perturbation_amplitude, pert_method)
 
 
 !----------------------------------------------------------------------

--- a/assimilation_code/programs/perturb_single_instance/perturb_single_instance.f90
+++ b/assimilation_code/programs/perturb_single_instance/perturb_single_instance.f90
@@ -45,7 +45,7 @@ use mpi_utilities_mod,    only : initialize_mpi_utilities, task_count, &
 use ensemble_manager_mod, only : ensemble_type, init_ensemble_manager, compute_copy_mean, &
                                  end_ensemble_manager
 
-use perturb_mod,          only : perturb_ensemble, PERT_MODEL_MOD, PERT_UNIFORM
+use perturb_mod,          only : perturb_ensemble
 
 implicit none
 
@@ -60,8 +60,11 @@ character(len=256)    :: output_file_list(MAX_NUM_DOMS) = ''
 character(len=256)    :: output_files(MAX_FILES)        = '' 
 real(r8)              :: perturbation_amplitude         = 0.0
 logical               :: single_restart_file_in         = .false.
-! Perturb all variables uniformly for a clean test of observation localization
-logical               :: perturb_for_localization_test  = .false.
+! How to perturb: 'model' lets the model_mod do it, falling back to a
+! perturbation that is bitwise across any number of tasks.  'uniform'
+! perturbs every state variable identically, for a clean test of
+! observation localization.
+character(len=32)     :: perturbation_method            = 'model'
 
 namelist /perturb_single_instance_nml/  &
    ens_size,                &
@@ -69,7 +72,7 @@ namelist /perturb_single_instance_nml/  &
    output_files,            &
    output_file_list,        &
    perturbation_amplitude,  &
-   perturb_for_localization_test, &
+   perturbation_method,     &
    single_restart_file_in
 
 !----------------------------------------------------------------
@@ -82,7 +85,6 @@ character(len=512)              :: msgstring, msgstring1
 character(len=256)              :: my_base, my_desc
 integer                         :: idom, imem, iunit, io
 integer                         :: ndomains
-integer                         :: pert_method ! how to perturb the single instance
 integer(i8)                     :: model_size
 type(time_type)                 :: member_time
 type(file_info_type)            :: file_info_input, file_info_output
@@ -108,12 +110,6 @@ if (single_restart_file_in) then
    write(msgstring,  *) 'single_restart_file_in is not supported.'
    write(msgstring1, *) 'Please contact DART if you would like to use this capability.'
    call error_handler(E_ERR,msgstring,msgstring1)
-endif
-
-if (perturb_for_localization_test) then
-   pert_method = PERT_UNIFORM
-else
-   pert_method = PERT_MODEL_MOD
 endif
 
 !----------------------------------------------------------------------
@@ -200,7 +196,7 @@ call read_state(ens_handle, file_info_input, read_time_from_file=.true., model_t
 ! provides no pert_model_copies, perturb_ensemble falls back to a
 ! perturbation that is bitwise across any number of tasks.
 !----------------------------------------------------------------------
-call perturb_ensemble(ens_handle, ens_size, perturbation_amplitude, pert_method)
+call perturb_ensemble(ens_handle, ens_size, perturbation_amplitude, perturbation_method)
 
 
 !----------------------------------------------------------------------

--- a/assimilation_code/programs/perturb_single_instance/perturb_single_instance.nml
+++ b/assimilation_code/programs/perturb_single_instance/perturb_single_instance.nml
@@ -5,6 +5,7 @@
    output_files           = ''
    output_file_list       = ''
    perturbation_amplitude = 0.0
+   perturb_for_localization_test = .false.
    single_restart_file_in = .false.,
  /
 

--- a/assimilation_code/programs/perturb_single_instance/perturb_single_instance.nml
+++ b/assimilation_code/programs/perturb_single_instance/perturb_single_instance.nml
@@ -5,7 +5,7 @@
    output_files           = ''
    output_file_list       = ''
    perturbation_amplitude = 0.0
-   perturb_for_localization_test = .false.
+   perturbation_method    = 'model'
    single_restart_file_in = .false.,
  /
 

--- a/assimilation_code/programs/perturb_single_instance/perturb_single_instance.rst
+++ b/assimilation_code/programs/perturb_single_instance/perturb_single_instance.rst
@@ -23,35 +23,50 @@ namelist.
       input_files            = ''      
       output_files           = ''
       output_file_list       = ''
-      perturbation_amplitude = 0.0     
-      single_restart_file_in = .false.      
+      perturbation_amplitude = 0.0
+      perturb_for_localization_test = .false.
+      single_restart_file_in = .false.
      /
 
 .. container::
 
-   +------------------------+-------------------------------------------+---------------------------------------------+
-   | Item                   | Type                                      | Description                                 |
-   +========================+===========================================+=============================================+
-   | ens_size               | integer                                   | Total number of ensemble members.           |
-   +------------------------+-------------------------------------------+---------------------------------------------+
-   | input_files            | character(len=256),dimension(num_domains) | The restart file you would like to perturb  |
-   |                        |                                           | from.                                       |
-   +------------------------+-------------------------------------------+---------------------------------------------+
-   | output_file_list       | character(len=256)                        | A file containing a list of the desired     |
-   |                        |                                           | output names.                               |
-   +------------------------+-------------------------------------------+---------------------------------------------+
-   | output_files           | character(len=256)                        | An array of filenames                       |
-   +------------------------+-------------------------------------------+---------------------------------------------+
-   | perturbation_amplitude | real(r8)                                  | The desired perturbation amplitude. If the  |
-   |                        |                                           | model provides an interface then it will    |
-   |                        |                                           | use that subroutine, otherwise it will      |
-   |                        |                                           | simply add gaussian noise to the entire     |
-   |                        |                                           | state, and this is the standard deviation.  |
-   +------------------------+-------------------------------------------+---------------------------------------------+
-   | single_restart_file_in | logical                                   | A boolean, specifying if you have a single  |
-   |                        |                                           | file restart, such as the case for lower    |
-   |                        |                                           | order models.                               |
-   +------------------------+-------------------------------------------+---------------------------------------------+
+   +-------------------------------+-------------------------------------------+---------------------------------------------+
+   | Item                          | Type                                      | Description                                 |
+   +===============================+===========================================+=============================================+
+   | ens_size                      | integer                                   | Total number of ensemble members.           |
+   +-------------------------------+-------------------------------------------+---------------------------------------------+
+   | input_files                   | character(len=256),dimension(num_domains) | The restart file you would like to perturb  |
+   |                               |                                           | from.                                       |
+   +-------------------------------+-------------------------------------------+---------------------------------------------+
+   | output_file_list              | character(len=256)                        | A file containing a list of the desired     |
+   |                               |                                           | output names.                               |
+   +-------------------------------+-------------------------------------------+---------------------------------------------+
+   | output_files                  | character(len=256)                        | An array of filenames                       |
+   +-------------------------------+-------------------------------------------+---------------------------------------------+
+   | perturbation_amplitude        | real(r8)                                  | The desired perturbation amplitude. If the  |
+   |                               |                                           | model provides an interface then it will    |
+   |                               |                                           | use that subroutine, otherwise it will      |
+   |                               |                                           | simply add gaussian noise to the entire     |
+   |                               |                                           | state, and this is the standard deviation.  |
+   +-------------------------------+-------------------------------------------+---------------------------------------------+
+   | perturb_for_localization_test | logical                                   | If true, every state variable is given the  |
+   |                               |                                           | same set of member offsets, so the          |
+   |                               |                                           | covariance of an observation with any state |
+   |                               |                                           | variable is identical. That leaves the      |
+   |                               |                                           | localization as the only source of          |
+   |                               |                                           | variability in the increments, which makes  |
+   |                               |                                           | it easy to display the details of the       |
+   |                               |                                           | localization. In this case                  |
+   |                               |                                           | perturbation_amplitude is a spacing rather  |
+   |                               |                                           | than a standard deviation: the perturbed    |
+   |                               |                                           | values are                                  |
+   |                               |                                           | x_i=x_1+(i-1)*perturbation_amplitude, so    |
+   |                               |                                           | the spread grows with the ensemble size.    |
+   +-------------------------------+-------------------------------------------+---------------------------------------------+
+   | single_restart_file_in        | logical                                   | A boolean, specifying if you have a single  |
+   |                               |                                           | file restart, such as the case for lower    |
+   |                               |                                           | order models.                               |
+   +-------------------------------+-------------------------------------------+---------------------------------------------+
 
 Below is an example of a typical namelist for the perturb_single_instance.
 

--- a/assimilation_code/programs/perturb_single_instance/perturb_single_instance.rst
+++ b/assimilation_code/programs/perturb_single_instance/perturb_single_instance.rst
@@ -24,7 +24,7 @@ namelist.
       output_files           = ''
       output_file_list       = ''
       perturbation_amplitude = 0.0
-      perturb_for_localization_test = .false.
+      perturbation_method    = 'model'
       single_restart_file_in = .false.
      /
 
@@ -49,17 +49,22 @@ namelist.
    |                               |                                           | simply add gaussian noise to the entire     |
    |                               |                                           | state, and this is the standard deviation.  |
    +-------------------------------+-------------------------------------------+---------------------------------------------+
-   | perturb_for_localization_test | logical                                   | If true, every state variable is given the  |
-   |                               |                                           | same set of member offsets, so the          |
-   |                               |                                           | covariance of an observation with any state |
-   |                               |                                           | variable is identical. That leaves the      |
-   |                               |                                           | localization as the only source of          |
-   |                               |                                           | variability in the increments, which makes  |
-   |                               |                                           | it easy to display the details of the       |
-   |                               |                                           | localization. In this case                  |
-   |                               |                                           | perturbation_amplitude is a spacing rather  |
-   |                               |                                           | than a standard deviation: the perturbed    |
-   |                               |                                           | values are                                  |
+   | perturbation_method           | character(len=32)                         | How to perturb. Case insensitive. 'model'   |
+   |                               |                                           | lets the model_mod perturb via              |
+   |                               |                                           | pert_model_copies, falling back to a        |
+   |                               |                                           | perturbation that is bitwise across any     |
+   |                               |                                           | number of tasks if the model does not       |
+   |                               |                                           | provide that interface. 'uniform' gives     |
+   |                               |                                           | every state variable the same set of member |
+   |                               |                                           | perturbations, so the covariance of an      |
+   |                               |                                           | observation with any state variable is      |
+   |                               |                                           | identical. That leaves the localization as  |
+   |                               |                                           | the only source of variability in the       |
+   |                               |                                           | increments, which makes it easy to display  |
+   |                               |                                           | the details of the localization. For        |
+   |                               |                                           | uniform, perturbation_amplitude is a        |
+   |                               |                                           | spacing rather than a standard deviation:   |
+   |                               |                                           | the perturbed values are                    |
    |                               |                                           | x_i=x_1+(i-1)*perturbation_amplitude, so    |
    |                               |                                           | the spread grows with the ensemble size.    |
    +-------------------------------+-------------------------------------------+---------------------------------------------+

--- a/developer_tests/perturb/test_perturb.f90
+++ b/developer_tests/perturb/test_perturb.f90
@@ -1,0 +1,209 @@
+! DART software - Copyright UCAR. This open source software is provided
+! by UCAR, "as is", without charge, subject to all terms of use at
+! http://www.image.ucar.edu/DAReS/DART/DART_download
+!
+! Test the array level routines in perturb_mod.
+!
+! which take the copies array and the ensemble distribution as data (not ens_handle),
+! so a serial program can stand in for any number of tasks.  No MPI required.
+
+program perturb_test
+
+use types_mod,     only : r8, i8
+use utilities_mod, only : initialize_utilities, finalize_utilities
+use perturb_mod,   only : perturb_uniform, perturb_bitwise
+
+use test
+
+implicit none
+
+! Deliberately more copies than ens_size.  filter carries extras (mean, sd,
+! inflation) beyond the members, so a routine that assumed ens_size was
+! size(copies,1) would trample them.
+integer,  parameter :: ENS_SIZE   = 20
+integer,  parameter :: NUM_COPIES = ENS_SIZE + 3
+integer,  parameter :: NUM_VARS   = 40
+real(r8), parameter :: AMPLITUDE  = 0.1_r8
+real(r8), parameter :: TOL        = 1.0e-14_r8
+
+! output_flag = .false. keeps DART's start/finish banners off stdout.  
+! to stop 'ill formed plan' when using tapview
+call initialize_utilities('perturb_test', output_flag=.false.)
+
+call plan(14)
+
+call test_uniform()
+call test_bitwise_task_invariance()
+call test_no_vars_on_this_task()
+
+call finalize_utilities()
+
+contains
+
+!------------------------------------------------------------------
+!> A single instance copied to every member,
+!> need to not have the sd the same everywhere, so that perturb_uniform can be checked.
+
+subroutine fill_single_instance(copies)
+
+real(r8), intent(out) :: copies(:,:)
+
+integer :: i
+
+do i = 1, size(copies, 2)
+   copies(:, i) = 3.0_r8 * i - 17.0_r8
+enddo
+
+end subroutine fill_single_instance
+
+!------------------------------------------------------------------
+!> Sample standard deviation over the ensemble members at one element.
+
+function member_sd(copies, ivar)
+
+real(r8), intent(in) :: copies(:,:)
+integer,  intent(in) :: ivar
+real(r8)             :: member_sd
+
+real(r8) :: mean
+
+mean      = sum(copies(1:ENS_SIZE, ivar)) / real(ENS_SIZE, r8)
+member_sd = sqrt(sum((copies(1:ENS_SIZE, ivar) - mean)**2) / real(ENS_SIZE - 1, r8))
+
+end function member_sd
+
+!------------------------------------------------------------------
+!> The point of the uniform perturbation: the spread is the same at every
+!> state element, so the covariance of an observation with any state
+!> variable is identical and localization is the only thing left varying.
+!>
+!> Also checks that ens_size is honoured as an argument rather than taken
+!> from size(copies,1), which would overwrite filter's extra copies.
+
+subroutine test_uniform()
+
+real(r8) :: copies(NUM_COPIES, NUM_VARS)
+real(r8) :: sds(NUM_VARS)
+real(r8) :: expected_sd, dev1, worst_dev
+integer  :: i, j
+
+call fill_single_instance(copies)
+call perturb_uniform(copies, ENS_SIZE, AMPLITUDE)
+
+! spread is amplitude*sqrt(N(N+1)/12), and the same everywhere
+expected_sd = AMPLITUDE * sqrt(real(ENS_SIZE, r8) * real(ENS_SIZE + 1, r8) / 12.0_r8)
+do i = 1, NUM_VARS
+   sds(i) = member_sd(copies, i)
+enddo
+call isabs(minval(sds), expected_sd, TOL, 'uniform: smallest sd is amplitude*sqrt(N(N+1)/12)')
+call isabs(maxval(sds), expected_sd, TOL, 'uniform: largest sd is amplitude*sqrt(N(N+1)/12)')
+
+! the member offsets must not depend on the state index
+worst_dev = 0.0_r8
+do j = 1, ENS_SIZE
+   dev1 = copies(j, 1) - copies(1, 1)
+   do i = 1, NUM_VARS
+      worst_dev = max(worst_dev, abs((copies(j, i) - copies(1, i)) - dev1))
+   enddo
+enddo
+call isabs(worst_dev, 0.0_r8, TOL, 'uniform: member offsets do not depend on the state index')
+
+! member 1 is the instance that was read in, it must not move
+call ok(all([(abs(copies(1, i) - (3.0_r8 * i - 17.0_r8)) < TOL, i = 1, NUM_VARS)]), &
+        'uniform: member 1 is unchanged')
+
+! the copies above ens_size belong to filter, not to us
+call ok(all([((abs(copies(j, i) - (3.0_r8 * i - 17.0_r8)) < TOL, &
+               j = ENS_SIZE + 1, NUM_COPIES), i = 1, NUM_VARS)]), &
+        'uniform: copies beyond ens_size are untouched')
+
+end subroutine test_uniform
+
+!------------------------------------------------------------------
+!> perturb_bitwise must give the same answer however the state is split
+!> across tasks.  Run it single task (whole state), then split the state the
+!> way ensemble_manager does (round robin) for several task counts and
+!> check every owned element against the one task answer.
+
+subroutine test_bitwise_task_invariance()
+
+real(r8)    :: initial(NUM_COPIES, NUM_VARS)
+real(r8)    :: reference(NUM_COPIES, NUM_VARS)
+real(r8)    :: mine(NUM_COPIES, NUM_VARS)
+integer(i8) :: all_vars(NUM_VARS), my_vars(NUM_VARS)
+integer     :: ntasks, itask, i, j, my_num_vars
+logical     :: matches
+character(len=64) :: label
+
+! perturb_bitwise overwrites every member including member 1, so keep the
+! state as it was read in to seed each pretend task from
+call fill_single_instance(initial)
+
+! one task owns the whole state - this is the reference answer
+do i = 1, NUM_VARS
+   all_vars(i) = int(i, i8)
+enddo
+reference = initial
+!                   (copies,    ens_size, my_vars,  num_vars,          amplitude)
+call perturb_bitwise(reference, ENS_SIZE, all_vars, int(NUM_VARS, i8), AMPLITUDE)
+
+! a routine that quietly did nothing would pass every comparison below
+call ok(abs(reference(2,1) - reference(1,1)) > TOL, &
+        'bitwise: the reference run actually perturbed the state')
+
+do ntasks = 2, 7
+
+   matches = .true.
+
+   do itask = 0, ntasks - 1
+
+      ! round robin following what ensemble_manager does
+      my_num_vars = 0
+      do i = itask + 1, NUM_VARS, ntasks
+         my_num_vars = my_num_vars + 1
+         my_vars(my_num_vars) = int(i, i8)
+      enddo
+
+      ! this task holds only its own elements, as they were read in
+      do i = 1, my_num_vars
+         mine(:, i) = initial(:, my_vars(i))
+      enddo
+
+      call perturb_bitwise(mine(:, 1:my_num_vars), ENS_SIZE, &
+                           my_vars(1:my_num_vars), int(NUM_VARS, i8), AMPLITUDE)
+
+      do i = 1, my_num_vars
+         do j = 1, ENS_SIZE
+            if (mine(j, i) /= reference(j, my_vars(i))) matches = .false.
+         enddo
+      enddo
+
+   enddo
+
+   write(label, '(A,I2,A)') 'bitwise: ', ntasks, ' tasks give the 1 task answer, bit for bit'
+   call ok(matches, trim(label))
+
+enddo
+
+end subroutine test_bitwise_task_invariance
+
+!------------------------------------------------------------------
+!> With more tasks than state elements a task can own nothing.  Indexing
+!> copies with the local index would run off the end of a zero size array.
+
+subroutine test_no_vars_on_this_task()
+
+real(r8)    :: copies(NUM_COPIES, 0)
+integer(i8) :: my_vars(0)
+
+call perturb_bitwise(copies, ENS_SIZE, my_vars, int(NUM_VARS, i8), AMPLITUDE)
+call pass('bitwise: a task owning no state returns without faulting')
+
+call perturb_uniform(copies, ENS_SIZE, AMPLITUDE)
+call pass('uniform: a task owning no state returns without faulting')
+
+end subroutine test_no_vars_on_this_task
+
+!------------------------------------------------------------------
+
+end program perturb_test

--- a/developer_tests/perturb/test_perturb.f90
+++ b/developer_tests/perturb/test_perturb.f90
@@ -13,7 +13,7 @@ use types_mod,     only : r8, i8
 use utilities_mod, only : initialize_utilities, finalize_utilities
 use perturb_mod,   only : perturb_uniform, perturb_bitwise
 
-use test
+use test,          only : ok, plan, isabs, pass
 
 implicit none
 

--- a/developer_tests/perturb/work/input.nml
+++ b/developer_tests/perturb/work/input.nml
@@ -1,0 +1,19 @@
+&utilities_nml
+   module_details = .false.,
+   write_nml = 'none'
+   /
+
+&mpi_utilities_nml
+   /
+
+&ensemble_manager_nml
+   /
+
+&preprocess_nml
+   input_obs_qty_mod_file  = '../../../assimilation_code/modules/observations/DEFAULT_obs_kind_mod.F90'
+   output_obs_qty_mod_file = '../../../assimilation_code/modules/observations/obs_kind_mod.f90'
+   input_obs_def_mod_file  = '../../../observations/forward_operators/DEFAULT_obs_def_mod.F90'
+   output_obs_def_mod_file = '../../../observations/forward_operators/obs_def_mod.f90'
+   obs_type_files          = '../../../observations/forward_operators/obs_def_gps_mod.f90'
+   quantity_files          = '../../../assimilation_code/modules/observations/default_quantities_mod.f90'
+   /

--- a/developer_tests/perturb/work/quickbuild.sh
+++ b/developer_tests/perturb/work/quickbuild.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# DART software - Copyright UCAR. This open source software is provided
+# by UCAR, "as is", without charge, subject to all terms of use at
+# http://www.image.ucar.edu/DAReS/DART/DART_download
+
+main() {
+
+export DART=$(git rev-parse --show-toplevel)
+source "$DART"/build_templates/buildfunctions.sh
+
+MODEL="none"
+EXTRA="$DART"/models/template/threed_model_mod.f90
+LOCATION="threed_sphere"
+dev_test=1
+TEST="perturb"
+
+serial_programs=(
+test_perturb
+)
+
+# quickbuild arguments
+arguments "$@"
+
+# clean the directory
+\rm -f -- *.o *.mod Makefile .cppdefs
+
+# build and run preprocess before making any other DART executables
+buildpreprocess
+
+# build
+buildit
+
+# clean up
+\rm -f -- *.o *.mod
+
+}
+
+main "$@"

--- a/guide/instructions-for-porting-a-new-model-to-dart.rst
+++ b/guide/instructions-for-porting-a-new-model-to-dart.rst
@@ -294,7 +294,7 @@ it can ingest these directly.  If not, an additional step is needed to copy
 over the updated values for the next model run.
 
 
-Testing Localization for a New Model or New Forward Operator
+Testing Localization Using a Single Observation and An Idealized Ensemble
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 One suggested step for testing the implementation of a new model or a new 

--- a/guide/instructions-for-porting-a-new-model-to-dart.rst
+++ b/guide/instructions-for-porting-a-new-model-to-dart.rst
@@ -293,3 +293,34 @@ item will contain the changed values.  If your model is reading NetCDF format
 it can ingest these directly.  If not, an additional step is needed to copy
 over the updated values for the next model run.
 
+
+Testing Localization for a New Model or New Forward Operator
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+One suggested step for testing the implementation of a new model or a new 
+observation forward operator with DART is to examine the impact of assimilating 
+a single observation. A recommended way to do this is to create an idealized 
+initial ensemble in which the ensemble perturbations are identical for all 
+state variables. DART provides this capability as a version of the 
+perturb_from_single_instance method that was described earlier in this section. 
+In &filter_nml namelist, set ‘perturb_from_single_instance’ to .true. and set 
+‘perturbation_method’ to ‘uniform’. This will generate an initial ensemble where 
+for every state variable, the difference between the ith ensemble member and the 
+first ensemble member is (i-1)*P where P is the ‘perturbation_amplitude’ in the 
+namelist. The covariance between the prior for an observation and all state 
+variables is the same in this case. With no localization, the increment for every 
+state variable will be identical. With localization turned on, the details of the 
+localization are clearly revealed by examining the observation increments. An 
+observation sequence with a single observation in it can be created using the 
+instructions earlier in this section. The time of the observation should be the 
+same as the time of the model state being used so that no model advance is 
+required in ‘filter’ before the assimilation (the advance would alter the nice 
+characteristics of the ensemble). Inflation and sampling error correction should 
+be turned off, at least for basic tests. Running ‘perfect_model_obs’ and ‘filter’ 
+will produce output files and the difference between the prior (preassim) and 
+posterior (analysis) outputs should reveal the pattern of localization. Note that 
+vertical localization in realistic Earth system models like CAM, MPAS, WRF, MOM 
+and POP is affected by the vertical coordinate choices and may lead to 
+localization patterns that are not as nicely circular in the horizontal as one 
+might expect. In large models, it is often a good step to begin with 
+‘horiz_dist_only’ set to .true. in &location_nml. 


### PR DESCRIPTION
Modified filter_mod.f90 so that it can generate uniform ensemble perturbations to every state variable. This means that the covariance of an observation is the same with every state variable. The only think that leads to non-uniform increments is the localization, so it can be easily displayed and studied. Changes include a new logical nameless entry for filter called perturb_for_localization_test. If this and perturb_from_single_instance are both true, the new perturbation method is applied. The perturbations are computed in the new subroutine perturb_copies_uniform.

This is a new feature which adds functionality and has no impact if the new nameless parameter is false (default). The filter.rst documentation has been updated.

The new method was tested with single observations for CAM, CLM, and Lorenz-96, and in strongly coupled tests where a single cam observation impacts CLM and a single CLM observation impacts CAM. Visual inspection of the results shows the localization patterns clearly.

fixes #967 

