### PR TITLE
use obs_ens_handle for get_var_owner_index and broadcast in seq_obs do loop

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,23 @@ individual files.
 
 The changes are now listed with the most recent at the top.
 
+**August 26 2026 :: pyjedi IODA QC Tag v11.25.2**
+
+Fixes:
+
+ - ObsQcName can be PreQC or QualityMarker depending on the IODA version.
+   *contributed by Shawn Murdzek, CIRES*
+ - Enforce terrain following coordinates in WRF scripting.
+
+Documentation:
+
+ - External (precomputed) Forward Operator documentation.
+
+Repo change:
+
+ - CIRRUS actions nvfortran compiler bug workaround.
+ - CIRRUS actions openmpi shared memory bug workaround.
+
 **August 10 2026 :: Localization Test Perturbations. Tag v11.25.1**
 
 New Testing Utility:

--- a/assimilation_code/modules/assimilation/assim_tools_mod.f90
+++ b/assimilation_code/modules/assimilation/assim_tools_mod.f90
@@ -614,11 +614,11 @@ SEQUENTIAL_OBS: do i = 1, obs_ens_handle%num_vars
    call get_obs_values(observation, obs, obs_val_index)
 
    ! Find out who has this observation and where it is
-   call get_var_owner_index(ens_handle, int(i,i8), owner, owners_index)
+   call get_var_owner_index(obs_ens_handle, int(i,i8), owner, owners_index)
 
    ! Following block is done only by the owner of this observation
    !-----------------------------------------------------------------------
-   if(ens_handle%my_pe == owner) then
+   if(obs_ens_handle%my_pe == owner) then
       ! each task has its own subset of all obs.  if they were converted in the
       ! vertical up above, then we need to broadcast the new values to all the other
       ! tasks so they're computing the right distances when applying the increments.
@@ -655,7 +655,7 @@ SEQUENTIAL_OBS: do i = 1, obs_ens_handle%num_vars
       ! vertvalue_obs_in_localization_coord and whichvert_real only used for vertical
       ! coordinate transformation
       whichvert_real = real(whichvert_obs_in_localization_coord, r8)
-      call broadcast_send(map_pe_to_task(ens_handle, owner), obs_prior,    &
+      call broadcast_send(map_pe_to_task(obs_ens_handle, owner), obs_prior,    &
          orig_obs_prior_mean, orig_obs_prior_var,                          &
          scalar1=obs_qc, scalar2=vertvalue_obs_in_localization_coord,      &
          scalar3=whichvert_real, scalar4=my_inflate, scalar5=my_inflate_sd)
@@ -663,7 +663,7 @@ SEQUENTIAL_OBS: do i = 1, obs_ens_handle%num_vars
    ! Next block is done by processes that do NOT own this observation
    !-----------------------------------------------------------------------
    else
-      call broadcast_recv(map_pe_to_task(ens_handle, owner), obs_prior,    &
+      call broadcast_recv(map_pe_to_task(obs_ens_handle, owner), obs_prior,    &
          orig_obs_prior_mean, orig_obs_prior_var,                          & 
          scalar1=obs_qc, scalar2=vertvalue_obs_in_localization_coord,      &
          scalar3=whichvert_real, scalar4=my_inflate, scalar5=my_inflate_sd)

--- a/conf.py
+++ b/conf.py
@@ -21,7 +21,7 @@ copyright = '2023, University Corporation for Atmospheric Research'
 author = 'Data Assimilation Research Section'
 
 # The full version, including alpha/beta/rc tags
-release = '11.25.1'
+release = '11.25.2'
 root_doc = 'index'
 
 # -- General configuration ---------------------------------------------------

--- a/models/wrf/readme.rst
+++ b/models/wrf/readme.rst
@@ -34,7 +34,7 @@ Some important WRF-DART updates include:
 
    The mandatory use of terrain following coordinates was imposed given suboptimal performance
    of sigma hybrid coordinates when using pert_wrf_bc to generate a perturbed BC ensemble
-   based on standard WRF-DART scripting. See `Issue #807 https://github.com/NCAR/DART/issues/807>`__
+   based on standard WRF-DART scripting. See `Issue #807 <https://github.com/NCAR/DART/issues/807>`_
    Users may choose to use sigma hybrid coordinates if they provide a custom BC ensemble.
 
 It is always recommended that you update your DART version to the 


### PR DESCRIPTION
## Description:

Use obs_ens_handle for get_var_owner_index and broadcast rather than ens_handle
Note the get_var_owner_index does not use ens_handle passed to it. 

map_pe_to_task _does_ use the ensemble handle, which is used in the broadcast.  You could have set a different layout (mapping of physical to logical tasks) when you initialize the ensemble handles. There is a note in ensemble manager that you should no do this.

https://github.com/NCAR/DART/blob/b270ca69bee4915141f0948043c64d5c9b263e5a/assimilation_code/modules/utilities/ensemble_manager_mod.f90#L165-L172

Q. Why even have layout as an option, many parts of the code assume the layout is the same for ens, obs_ens, and qc_obs_ens?   "Do not shoot your self in the foot with this foot gun we have provided"


### Fixes issue
<!--- link to github issue(s) -->
fixes #1163


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

I do not think this bug has caused problems, however if someone did pass different layouts to the various ensemble initializations this would cause problems. 

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

### Tests
Please describe any tests you ran to verify your changes.
Bitwise lorenz_96 with mpi (4,5, procs my mac) & serial

## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [ ] No dataset needed
