### PR TITLE
ci: patch for nvfortran in cirrus actions & workaround for openmpi gfortran

### DIFF
--- a/.github/patches/nvhpc-obs_diag-bounds.patch
+++ b/.github/patches/nvhpc-obs_diag-bounds.patch
@@ -1,0 +1,24 @@
+diff --git a/assimilation_code/programs/obs_diag/oned/obs_diag.f90 b/assimilation_code/programs/obs_diag/oned/obs_diag.f90
+index e12587186..e4510d494 100644
+--- a/assimilation_code/programs/obs_diag/oned/obs_diag.f90
++++ b/assimilation_code/programs/obs_diag/oned/obs_diag.f90
+@@ -1774,9 +1774,16 @@ end function Rank_Histogram
+               'model - observation' ), 'WriteNetCDF', 'put_att bias '//trim(fname))
+ 
+    if ( create_rank_histogram ) then
+-      call nc_check(nf90_put_att(ncid, NF90_GLOBAL, 'DART_QCs_in_histogram', &
+-              hist_qcs(1:numqcvals) ), &
+-              'WriteNetCDF', 'put_att qcs in histogram '//trim(fname))
++      ! WORKAROUND: nvfortran 26.5 fort1 SIGSEGVs with -C on a section of a
++      ! default-integer PARAMETER array passed to a module procedure.
++      ! Copying into a local variable dodges it. Remove once nvhpc is fixed.
++      block
++         integer :: qcs_used(size(hist_qcs))
++         qcs_used = hist_qcs
++         call nc_check(nf90_put_att(ncid, NF90_GLOBAL, 'DART_QCs_in_histogram', &
++                 qcs_used(1:numqcvals) ), &
++                 'WriteNetCDF', 'put_att qcs in histogram '//trim(fname))
++      end block
+ 
+       if ( outliers_in_histogram ) then
+       call nc_check(nf90_put_att(ncid, NF90_GLOBAL, 'outliers_in_histogram', &

--- a/.github/workflows/cirrus_action_on_pull_request.yml
+++ b/.github/workflows/cirrus_action_on_pull_request.yml
@@ -67,6 +67,15 @@ jobs:
           sed -i 's/LD = ftn/LD = nvfortran/' mkmf.template.nvhpc
           sed -i 's/FC = ftn/FC = nvfortran/' mkmf.template.nvhpc
 
+      # nvfortran 26.5 crashes its front end (fort1, SIGSEGV) under -C on an
+      # array section of a default-integer PARAMETER array passed to a module
+      # procedure. obs_diag hits this via nf90_put_att. Reported to NVIDIA;
+      # delete this step and .github/patches/ once a fixed nvhpc is in the
+      # container image.
+      - name: Work around nvfortran -C front-end crash in obs_diag
+        if: matrix.compiler == 'nvhpc'
+        run: git apply --verbose .github/patches/nvhpc-obs_diag-bounds.patch
+
       - name: Build and run lorenz_96
         uses: ./.github/actions/build_run_model
         with:

--- a/.github/workflows/cirrus_action_on_pull_request.yml
+++ b/.github/workflows/cirrus_action_on_pull_request.yml
@@ -52,6 +52,17 @@ jobs:
       - name: Set checked out repo as a safe git directory
         run: git config --global --add safe.directory /__w/${{ github.event.repository.name }}/${{ github.event.repository.name }}
 
+      # TEMPORARY WORKAROUND for issue #1118.  Open MPI 5.0.10's shared-memory
+      # BTL intermittently segfaults inside mca_btl_sm_poll_handle_frag,
+      # Only the gcc-built Open MPI is affected;
+      # the nvhpc and ifx images ship the same 5.0.10 built with nvfortran and
+      # ifx and do not fail.  
+      # Routing over tcp/self instead of shared memory.  
+      # Remove once the underlying problem is fixed.
+      - name: Disable Open MPI shared-memory BTL (gfortran only)
+        if: matrix.compiler == 'gfortran' && matrix.use-mpi != 'nompi'
+        run: echo "OMPI_MCA_btl=^sm" >> "$GITHUB_ENV"
+
       - name: Source container config file and modify mkmf to use 4 cores for compilation
         run: |
           source "/container/config_env.sh"


### PR DESCRIPTION
## Description:
<!--- Describe your changes -->

Two CIRRUS fixes: 

**1. Applies a patch for nvfortran in cirrus actions so obs_diag wil compile**
nvfortran bug with -C descibed in #1150.

patch only for 1d obs_diag since that is what is run in CI.
Put in as a patch rather than DART code changes so it can be removed once nvfortran fixes their bug. 
 
### Fixes issue
<!--- link to github issue(s) -->
Bug is reported in #1150


**2. cirrus gfortran open mpi workaround**

see #1118 for details (or pull #1171)
Segfaults in mca_btl_sm_poll_handle_frag

BTL intermittently segfaults inside mca_btl_sm_poll_handle_frag,
Only the gcc-built Open MPI is affected so only  disabling the shared memory (sm) Byte Transport Layer component 
if the compiler is gfortran and using mpi (or mpif08). 

It is this container: docker.io/ncarcisl/hpcdev-x86_64:almalinux10-gcc-openmpi-latest

### Fixes issue
<!--- link to github issue(s) -->
not fixes, just workaround #1118 


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) **workaround** in CI
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update


### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

### Tests
Please describe any tests you ran to verify your changes.
Testing with this pull request!

## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [ ] No dataset needed
