### PR TITLE
cirrus gfortran open mpi workaround

### DIFF
--- a/.github/workflows/cirrus_action_on_pull_request.yml
+++ b/.github/workflows/cirrus_action_on_pull_request.yml
@@ -52,6 +52,17 @@ jobs:
       - name: Set checked out repo as a safe git directory
         run: git config --global --add safe.directory /__w/${{ github.event.repository.name }}/${{ github.event.repository.name }}
 
+      # TEMPORARY WORKAROUND for issue #1118.  Open MPI 5.0.10's shared-memory
+      # BTL intermittently segfaults inside mca_btl_sm_poll_handle_frag,
+      # Only the gcc-built Open MPI is affected;
+      # the nvhpc and ifx images ship the same 5.0.10 built with nvfortran and
+      # ifx and do not fail.  
+      # Routing over tcp/self instead of shared memory.  
+      # Remove once the underlying problem is fixed.
+      - name: Disable Open MPI shared-memory BTL (gfortran only)
+        if: matrix.compiler == 'gfortran' && matrix.use-mpi != 'nompi'
+        run: echo "OMPI_MCA_btl=^sm" >> "$GITHUB_ENV"
+
       - name: Source container config file and modify mkmf to use 4 cores for compilation
         run: |
           source "/container/config_env.sh"


### PR DESCRIPTION
## Description:
<!--- Describe your changes -->
cirrus gfortran open mpi workaround

see #1118 for details
Segfaults in mca_btl_sm_poll_handle_frag

BTL intermittently segfaults inside mca_btl_sm_poll_handle_frag,
Only the gcc-built Open MPI is affected so only  disabling the shared memory (sm) Byte Transport Layer component 
if the compiler is gfortran and using mpi (or mpif08). 

It is this container: docker.io/ncarcisl/hpcdev-x86_64:almalinux10-gcc-openmpi-latest

### Fixes issue
<!--- link to github issue(s) -->
not fixes, just workaround #1118 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] CIRRUS workaround

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

### Tests
Please describe any tests you ran to verify your changes.
Running locally with Docker : docker.io/ncarcisl/hpcdev-x86_64:almalinux10-gcc-openmpi-latest
Note I cannot reproduce the problem using the aarch64 container. 
This pull request is testing the CIRRUS run

## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [ ] No dataset needed
