### PR TITLE
initialize doscalar to .false. in mpi{f08} utilities

### DIFF
--- a/assimilation_code/modules/utilities/mpi_utilities_mod.f90
+++ b/assimilation_code/modules/utilities/mpi_utilities_mod.f90
@@ -1011,6 +1011,7 @@ subroutine countup(array1, array2, array3, array4, array5, &
  logical,  intent(out)          :: morethanone, doscalar
 
 morethanone = .false.
+doscalar = .false.
 numitems = size(array1)
 
 if (present(array2)) then

--- a/assimilation_code/modules/utilities/mpif08_utilities_mod.f90
+++ b/assimilation_code/modules/utilities/mpif08_utilities_mod.f90
@@ -1011,6 +1011,7 @@ subroutine countup(array1, array2, array3, array4, array5, &
  logical,  intent(out)          :: morethanone, doscalar
 
 morethanone = .false.
+doscalar = .false.
 numitems = size(array1)
 
 if (present(array2)) then


### PR DESCRIPTION
## Description:
<!--- Describe your changes -->
Please provide a summary of the change and include any relevant motivation and context. 

mpi utilties and mpif08 utitlies use `countup` to "figure out how many items are in the specified arrays, total.
also note if there's more than a single array (array1) to send, and if there are any scalars specified."

The intent(out) doscalar is not set unless a scalar is present. If no scalar is present, doscalar is undefined on return.
This pull request initializes doscalar to .false.

null_mpi_utitiles does not use `countup`. 

### Fixes issue
<!--- link to github issue(s) -->
fixes #1169 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

### Tests
Please describe any tests you ran to verify your changes.

## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [ ] No dataset needed
