### PR TITLE
fix: bounds error in mpi{f08} utilities when make_copy_before_broadcast = .true.

### DIFF
--- a/assimilation_code/modules/utilities/mpi_utilities_mod.f90
+++ b/assimilation_code/modules/utilities/mpi_utilities_mod.f90
@@ -791,9 +791,9 @@ if (itemcount <= BCAST_MAXSIZE) then
    if (.not. make_copy_before_broadcast) then
       call MPI_Bcast(array, itemcount, datasize, root, my_local_comm, errcode)
    else
-      if (my_task_id() == root) tmpdata = array
+      if (my_task_id() == root) tmpdata = array(1:itemcount)
       call MPI_Bcast(tmpdata, itemcount, datasize, root, my_local_comm, errcode)
-      if (my_task_id() /= root) array = tmpdata
+      if (my_task_id() /= root) array(1:itemcount) = tmpdata
    endif
 else
    offset = 1

--- a/assimilation_code/modules/utilities/mpif08_utilities_mod.f90
+++ b/assimilation_code/modules/utilities/mpif08_utilities_mod.f90
@@ -791,9 +791,9 @@ if (itemcount <= BCAST_MAXSIZE) then
    if (.not. make_copy_before_broadcast) then
       call MPI_Bcast(array, itemcount, datasize, root, my_local_comm, errcode)
    else
-      if (my_task_id() == root) tmpdata = array
+      if (my_task_id() == root) tmpdata = array(1:itemcount)
       call MPI_Bcast(tmpdata, itemcount, datasize, root, my_local_comm, errcode)
-      if (my_task_id() /= root) array = tmpdata
+      if (my_task_id() /= root) array(1:itemcount) = tmpdata
    endif
 else
    offset = 1


### PR DESCRIPTION
## Description:
<!--- Describe your changes -->

When copy before broadcast is set to true, array is copied into a temporary variable. This variable was a different size to array and so gave an out-of-bounds error when doing the copy.

This pull request uses the itemcount to right-size the array copy (and copy back after broadcast).

Note you have to edit the code to switch on the mpi namelist to select "copy before broadcast" so I do not think users were hitting this, but it did trip me up debugging openmpi issues in openmpi in various containers #1118.

### Fixes issue
<!--- link to github issue(s) -->
fixes #1168

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

### Tests
Please describe any tests you ran to verify your changes.
Running lorenz_96 with mpi (and mpi_utitiles namelist) making a copy before broadcast.

## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [ ] No dataset needed
