### PR TITLE
docs: update mom6 model docs to be clear on ncar MOM6 and link to DART_interface docs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,7 +22,22 @@ individual files.
 
 The changes are now listed with the most recent at the top.
 
-**August 26 2026 :: pyjedi IODA QC Tag v11.25.2**
+**September 10 2026 :: MOM6 regional grids. Tag v11.25.3**
+
+Bug fixes:
+
+- MOM6 regional grids may have different sizes for t,u,v grids.
+- end_ensemble_manager check before deallocating.
+- Bounds error fix in mpi utilities when make_copy_before_broadcast = .true.
+- Initialize do_scalar in mpi_utilities.
+
+Documentation:
+
+- CROCODILE (DART as a CESM component) added to MOM6 docs.
+- rst fixes in da-in-dart-with-lorenz-63 page.
+
+
+**August 26 2026 :: pyjedi IODA QC. Tag v11.25.2**
 
 Fixes:
 

--- a/conf.py
+++ b/conf.py
@@ -21,7 +21,7 @@ copyright = '2023, University Corporation for Atmospheric Research'
 author = 'Data Assimilation Research Section'
 
 # The full version, including alpha/beta/rc tags
-release = '11.25.2'
+release = '11.25.3'
 root_doc = 'index'
 
 # -- General configuration ---------------------------------------------------

--- a/models/MOM6/readme.rst
+++ b/models/MOM6/readme.rst
@@ -5,9 +5,13 @@ A new ocean component model based on the Modular Ocean Model version 6 (MOM6) ha
 `CESM <https://www.cesm.ucar.edu/>`_ and is anticipated to replace POP2 as the default ocean component in CESM3.
 An early functional release of the MOM6 ocean component has been made available to users beginning with CESM2.2.
 Instructions for using MOM6 in CESM are available on the `MOM_interface GitHub Wiki
-<https://github.com/ESCOMP/MOM_interface/wiki>`_.
+<https://github.com/ESCOMP/MOM_interface/wiki>`_. This DART-MOM6 model_mod was developed for the NCAR fork of
+`MOM6 <https://github.com/NCAR/MOM6>`_ .
 
-This DART-MOM6 interface was developed for `MOM6 <https://github.com/NCAR/MOM6>`_ within the CESM framework.
+A DART_interface to run DART as a CESM3 component is under active development as part of the CROCODILE project for
+both regional and global MOM6 configurations. Information is available in the
+`DART interface documentation <https://crocodile-cesm.github.io/DART_interface/>`_, and the
+`CrocoDash tutorial notebooks <https://crocodile-cesm.github.io/CrocoGallery/latest/>`_
 
 MOM6 time
 ---------


### PR DESCRIPTION
## Description:
<!--- Describe your changes -->

This pull request changes the mom6 model_mod docs to be clear on the model_mod being developed for NCAR's version of MOM6. 

I've removed term 'interface' for the model mod, since CESM has interfaces for components. 
Added note on DART_interface (DART as a CESM component) with links to DART_interface documentation and crocodile workshop tutorials.

### Fixes issue
<!--- link to github issue(s) -->
fixes #1176

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

### Tests
Please describe any tests you ran to verify your changes.

## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [ ] No dataset needed
