### PR TITLE
fix: end_ensemble_manager check allocated variables are allocated bef…

### DIFF
--- a/assimilation_code/modules/utilities/ensemble_manager_mod.f90
+++ b/assimilation_code/modules/utilities/ensemble_manager_mod.f90
@@ -457,10 +457,13 @@ subroutine end_ensemble_manager(ens_handle)
 type(ensemble_type), intent(inout) :: ens_handle
 
 ! Free up the allocated storage
-deallocate(ens_handle%my_copies, ens_handle%time, ens_handle%my_vars, &
-           ens_handle%copies, ens_handle%task_to_pe_list, ens_handle%pe_to_task_list)
-
-if(allocated(ens_handle%vars)) deallocate(ens_handle%vars)
+if(allocated(ens_handle%my_copies))       deallocate(ens_handle%my_copies)
+if(allocated(ens_handle%time))            deallocate(ens_handle%time)
+if(allocated(ens_handle%my_vars))         deallocate(ens_handle%my_vars)
+if(allocated(ens_handle%copies))          deallocate(ens_handle%copies)
+if(allocated(ens_handle%task_to_pe_list)) deallocate(ens_handle%task_to_pe_list)
+if(allocated(ens_handle%pe_to_task_list)) deallocate(ens_handle%pe_to_task_list)
+if(allocated(ens_handle%vars))            deallocate(ens_handle%vars)
 
 end subroutine end_ensemble_manager
 


### PR DESCRIPTION
## Description:
<!--- Describe your changes -->

This pull request adds a check in end_ensemble_manager to only call deallocate on arrays that have been allocated. 

The allocatable variables in the type are:

integer,        allocatable  :: my_copies(:)
integer(i8),    allocatable  :: my_vars(:)
real(r8),       allocatable  :: copies(:, :)   
real(r8),       allocatable  :: vars(:, :) 
type(time_type), allocatable :: time(:)
integer, allocatable         :: task_to_pe_list(:), 
                                             pe_to_task_list(:) 

### Fixes issue
<!--- link to github issue(s) -->

fixes #1174

Note 1174 could be fixed by checking for num_obs_in_set = 0 and if so not ending fwd_op and qc ensemble handles, but I think the more general solution of checking if the arrays are allocated before deallocating in end_ensemble_manager. Because end_ensemble_manager is a cleanup routine so maybe you are bailing early, failing, or you have not realized perfect_model_obs can bail early - I don't think enforcing (by runtime error) a matching init/end for ensemble_manager is that helpful. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

### Tests
Please describe any tests you ran to verify your changes.

## Checklist for merging

- [ ] Updated changelog entry
- [ ] Documentation updated
- [ ] Update conf.py

## Checklist for release
- [ ] Merge into main
- [ ] Create release from the main branch with appropriate tag
- [ ] Delete feature-branch

## Testing Datasets

- [ ] Dataset needed for testing available upon request
- [ ] Dataset download instructions included
- [ ] No dataset needed
